### PR TITLE
Update React Testing Library version to 10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1416,11 +1416,14 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
-    "@sheerun/mutationobserver-shim": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
-      "integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==",
-      "dev": true
+    "@sinonjs/commons": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
+      "integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
     },
     "@styled-system/background": {
       "version": "5.1.2",
@@ -1716,24 +1719,22 @@
       }
     },
     "@testing-library/dom": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.16.0.tgz",
-      "integrity": "sha512-lBD88ssxqEfz0wFL6MeUyyWZfV/2cjEZZV3YRpb2IoJRej/4f1jB0TzqIOznTpfR1r34CNesrubxwIlAQ8zgPA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.2.0.tgz",
+      "integrity": "sha512-K1Sao38VxsTrjTkFkzeW8m/oCtgCI5lANCE7u9ZaF+TTL3uKuiZ+vazeurxjvRHAsE6PvXjOIl6JFuZfgcWJSQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.8.4",
-        "@sheerun/mutationobserver-shim": "^0.3.2",
-        "@types/testing-library__dom": "^6.12.1",
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__dom": "^7.0.0",
         "aria-query": "^4.0.2",
-        "dom-accessibility-api": "^0.3.0",
-        "pretty-format": "^25.1.0",
-        "wait-for-expect": "^3.0.2"
+        "dom-accessibility-api": "^0.4.2",
+        "pretty-format": "^25.1.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "25.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-          "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.6.tgz",
+          "integrity": "sha512-myJTTV37bxK7+3NgKc4Y/DlQ5q92/NOwZsZ+Uch7OXdElxOg61QYc72fPYNAjlvbnJ2YvbXLamIsa9tj48BmyQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1799,12 +1800,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "25.1.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.1.0.tgz",
-          "integrity": "sha512-46zLRSGLd02Rp+Lhad9zzuNZ+swunitn8zIpfD2B4OPCRLXbM87RJT2aBLBWYOznNUML/2l/ReMyWNC80PJBUQ==",
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.2.6.tgz",
+          "integrity": "sha512-DEiWxLBaCHneffrIT4B+TpMvkV9RNvvJrd3lY9ew1CEQobDzEXmYT1mg0hJhljZty7kCc10z13ohOFAE8jrUDg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^25.1.0",
+            "@jest/types": "^25.2.6",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
@@ -1839,14 +1840,14 @@
       }
     },
     "@testing-library/react": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-9.5.0.tgz",
-      "integrity": "sha512-di1b+D0p+rfeboHO5W7gTVeZDIK5+maEgstrZbWZSSvxDyfDRkkyBE1AJR5Psd6doNldluXlCWqXriUfqu/9Qg==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-10.0.2.tgz",
+      "integrity": "sha512-YT6Mw0oJz7R6vlEkmo1FlUD+K15FeXApOB5Ffm9zooFVnrwkt00w18dUJFMOh1yRp9wTdVRonbor7o4PIpFCmA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.8.4",
-        "@testing-library/dom": "^6.15.0",
-        "@types/testing-library__react": "^9.1.2"
+        "@babel/runtime": "^7.9.2",
+        "@testing-library/dom": "^7.1.0",
+        "@types/testing-library__react": "^10.0.0"
       }
     },
     "@testing-library/user-event": {
@@ -2263,29 +2264,18 @@
       }
     },
     "@types/testing-library__dom": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-6.14.0.tgz",
-      "integrity": "sha512-sMl7OSv0AvMOqn1UJ6j1unPMIHRXen0Ita1ujnMX912rrOcawe4f7wu0Zt9GIQhBhJvH2BaibqFgQ3lP+Pj2hA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-7.0.1.tgz",
+      "integrity": "sha512-WokGRksRJb3Dla6h02/0/NNHTkjsj4S8aJZiwMj/5/UL8VZ1iCe3H8SHzfpmBeH8Vp4SPRT8iC2o9kYULFhDIw==",
       "dev": true,
       "requires": {
-        "pretty-format": "^24.3.0"
-      }
-    },
-    "@types/testing-library__react": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__react/-/testing-library__react-9.1.3.tgz",
-      "integrity": "sha512-iCdNPKU3IsYwRK9JieSYAiX0+aYDXOGAmrC/3/M7AqqSDKnWWVv07X+Zk1uFSL7cMTUYzv4lQRfohucEocn5/w==",
-      "dev": true,
-      "requires": {
-        "@types/react-dom": "*",
-        "@types/testing-library__dom": "*",
         "pretty-format": "^25.1.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "25.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-          "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.6.tgz",
+          "integrity": "sha512-myJTTV37bxK7+3NgKc4Y/DlQ5q92/NOwZsZ+Uch7OXdElxOg61QYc72fPYNAjlvbnJ2YvbXLamIsa9tj48BmyQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2351,12 +2341,114 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "25.1.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.1.0.tgz",
-          "integrity": "sha512-46zLRSGLd02Rp+Lhad9zzuNZ+swunitn8zIpfD2B4OPCRLXbM87RJT2aBLBWYOznNUML/2l/ReMyWNC80PJBUQ==",
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.2.6.tgz",
+          "integrity": "sha512-DEiWxLBaCHneffrIT4B+TpMvkV9RNvvJrd3lY9ew1CEQobDzEXmYT1mg0hJhljZty7kCc10z13ohOFAE8jrUDg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^25.1.0",
+            "@jest/types": "^25.2.6",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@types/testing-library__react": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__react/-/testing-library__react-10.0.1.tgz",
+      "integrity": "sha512-RbDwmActAckbujLZeVO/daSfdL1pnjVqas25UueOkAY5r7vriavWf0Zqg7ghXMHa8ycD/kLkv8QOj31LmSYwww==",
+      "dev": true,
+      "requires": {
+        "@types/react-dom": "*",
+        "@types/testing-library__dom": "*",
+        "pretty-format": "^25.1.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.6.tgz",
+          "integrity": "sha512-myJTTV37bxK7+3NgKc4Y/DlQ5q92/NOwZsZ+Uch7OXdElxOg61QYc72fPYNAjlvbnJ2YvbXLamIsa9tj48BmyQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.4",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
+          "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.2.6.tgz",
+          "integrity": "sha512-DEiWxLBaCHneffrIT4B+TpMvkV9RNvvJrd3lY9ew1CEQobDzEXmYT1mg0hJhljZty7kCc10z13ohOFAE8jrUDg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.2.6",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
@@ -4689,6 +4781,12 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "decimal.js": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
+      "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==",
+      "dev": true
+    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -4944,9 +5042,9 @@
       }
     },
     "dom-accessibility-api": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.3.0.tgz",
-      "integrity": "sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.4.3.tgz",
+      "integrity": "sha512-JZ8iPuEHDQzq6q0k7PKMGbrIdsgBB7TRrtVOUm4nSMCExlg5qQG4KXWTH2k90yggjM4tTumRGwTKJSldMzKyLA==",
       "dev": true
     },
     "dom-converter": {
@@ -7439,6 +7537,12 @@
         "isobject": "^3.0.1"
       }
     },
+    "is-potential-custom-element-name": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
+      "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
+      "dev": true
+    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
@@ -7769,6 +7873,383 @@
           "requires": {
             "async-limiter": "~1.0.0"
           }
+        }
+      }
+    },
+    "jest-environment-jsdom-sixteen": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom-sixteen/-/jest-environment-jsdom-sixteen-1.0.3.tgz",
+      "integrity": "sha512-CwMqDUUfSl808uGPWXlNA1UFkWFgRmhHvyAjhCmCry6mYq4b/nn80MMN7tglqo5XgrANIs/w+mzINPzbZ4ZZrQ==",
+      "dev": true,
+      "requires": {
+        "@jest/fake-timers": "^25.1.0",
+        "jest-mock": "^25.1.0",
+        "jest-util": "^25.1.0",
+        "jsdom": "^16.2.1"
+      },
+      "dependencies": {
+        "@jest/fake-timers": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.2.6.tgz",
+          "integrity": "sha512-A6qtDIA2zg/hVgUJJYzQSHFBIp25vHdSxW/s4XmTJAYxER6eL0NQdQhe4+232uUSviKitubHGXXirt5M7blPiA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.2.6",
+            "jest-message-util": "^25.2.6",
+            "jest-mock": "^25.2.6",
+            "jest-util": "^25.2.6",
+            "lolex": "^5.0.0"
+          }
+        },
+        "@jest/types": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.6.tgz",
+          "integrity": "sha512-myJTTV37bxK7+3NgKc4Y/DlQ5q92/NOwZsZ+Uch7OXdElxOg61QYc72fPYNAjlvbnJ2YvbXLamIsa9tj48BmyQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.4",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
+          "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "acorn-globals": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+          "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+          "dev": true,
+          "requires": {
+            "acorn": "^7.1.1",
+            "acorn-walk": "^7.1.1"
+          }
+        },
+        "acorn-walk": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.1.1.tgz",
+          "integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "cssom": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+          "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+          "dev": true
+        },
+        "cssstyle": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.2.0.tgz",
+          "integrity": "sha512-sEb3XFPx3jNnCAMtqrXPDeSgQr+jojtCeNf8cvMNMh1cG970+lljssvQDzPq6lmmJu2Vhqood/gtEomBiHOGnA==",
+          "dev": true,
+          "requires": {
+            "cssom": "~0.3.6"
+          },
+          "dependencies": {
+            "cssom": {
+              "version": "0.3.8",
+              "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+              "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+              "dev": true
+            }
+          }
+        },
+        "data-urls": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+          "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+          "dev": true,
+          "requires": {
+            "abab": "^2.0.3",
+            "whatwg-mimetype": "^2.3.0",
+            "whatwg-url": "^8.0.0"
+          }
+        },
+        "domexception": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+          "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+          "dev": true,
+          "requires": {
+            "webidl-conversions": "^5.0.0"
+          },
+          "dependencies": {
+            "webidl-conversions": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+              "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+              "dev": true
+            }
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "html-encoding-sniffer": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+          "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+          "dev": true,
+          "requires": {
+            "whatwg-encoding": "^1.0.5"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "jest-message-util": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.2.6.tgz",
+          "integrity": "sha512-Hgg5HbOssSqOuj+xU1mi7m3Ti2nwSQJQf/kxEkrz2r2rp2ZLO1pMeKkz2WiDUWgSR+APstqz0uMFcE5yc0qdcg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/types": "^25.2.6",
+            "@types/stack-utils": "^1.0.1",
+            "chalk": "^3.0.0",
+            "micromatch": "^4.0.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^1.0.1"
+          }
+        },
+        "jest-mock": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.2.6.tgz",
+          "integrity": "sha512-vc4nibavi2RGPdj/MyZy/azuDjZhpYZLvpfgq1fxkhbyTpKVdG7CgmRVKJ7zgLpY5kuMjTzDYA6QnRwhsCU+tA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.2.6"
+          }
+        },
+        "jest-util": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.2.6.tgz",
+          "integrity": "sha512-gpXy0H5ymuQ0x2qgl1zzHg7LYHZYUmDEq6F7lhHA8M0eIwDB2WteOcCnQsohl9c/vBKZ3JF2r4EseipCZz3s4Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.2.6",
+            "chalk": "^3.0.0",
+            "is-ci": "^2.0.0",
+            "make-dir": "^3.0.0"
+          }
+        },
+        "jsdom": {
+          "version": "16.2.2",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.2.2.tgz",
+          "integrity": "sha512-pDFQbcYtKBHxRaP55zGXCJWgFHkDAYbKcsXEK/3Icu9nKYZkutUXfLBwbD+09XDutkYSHcgfQLZ0qvpAAm9mvg==",
+          "dev": true,
+          "requires": {
+            "abab": "^2.0.3",
+            "acorn": "^7.1.1",
+            "acorn-globals": "^6.0.0",
+            "cssom": "^0.4.4",
+            "cssstyle": "^2.2.0",
+            "data-urls": "^2.0.0",
+            "decimal.js": "^10.2.0",
+            "domexception": "^2.0.1",
+            "escodegen": "^1.14.1",
+            "html-encoding-sniffer": "^2.0.1",
+            "is-potential-custom-element-name": "^1.0.0",
+            "nwsapi": "^2.2.0",
+            "parse5": "5.1.1",
+            "request": "^2.88.2",
+            "request-promise-native": "^1.0.8",
+            "saxes": "^5.0.0",
+            "symbol-tree": "^3.2.4",
+            "tough-cookie": "^3.0.1",
+            "w3c-hr-time": "^1.0.2",
+            "w3c-xmlserializer": "^2.0.0",
+            "webidl-conversions": "^6.0.0",
+            "whatwg-encoding": "^1.0.5",
+            "whatwg-mimetype": "^2.3.0",
+            "whatwg-url": "^8.0.0",
+            "ws": "^7.2.3",
+            "xml-name-validator": "^3.0.0"
+          }
+        },
+        "make-dir": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "parse5": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+          "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+          "dev": true
+        },
+        "saxes": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.0.tgz",
+          "integrity": "sha512-LXTZygxhf8lfwKaTP/8N9CsVdjTlea3teze4lL6u37ivbgGbV0GGMuNtS/I9rnD/HC2/txUM7Df4S2LVl1qhiA==",
+          "dev": true,
+          "requires": {
+            "xmlchars": "^2.2.0"
+          }
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "tough-cookie": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+          "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+          "dev": true,
+          "requires": {
+            "ip-regex": "^2.1.0",
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "tr46": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+          "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "w3c-xmlserializer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+          "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+          "dev": true,
+          "requires": {
+            "xml-name-validator": "^3.0.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.0.0.tgz",
+          "integrity": "sha512-jTZAeJnc6D+yAOjygbJOs33kVQIk5H6fj9SFDOhIKjsf9HiAzL/c+tAJsc8ASWafvhNkH+wJZms47pmajkhatA==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.0.0.tgz",
+          "integrity": "sha512-41ou2Dugpij8/LPO5Pq64K5q++MnRCBpEHvQr26/mArEKTkCV5aoXIqyhuYtE0pkqScXwhf2JP57rkRTYM29lQ==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^2.0.0",
+            "webidl-conversions": "^5.0.0"
+          },
+          "dependencies": {
+            "webidl-conversions": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+              "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+              "dev": true
+            }
+          }
+        },
+        "ws": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
+          "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
+          "dev": true
         }
       }
     },
@@ -8953,6 +9434,15 @@
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",
       "integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A=="
+    },
+    "lolex": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+      "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -13737,6 +14227,12 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
     "type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
@@ -14049,12 +14545,6 @@
         "webidl-conversions": "^4.0.2",
         "xml-name-validator": "^3.0.0"
       }
-    },
-    "wait-for-expect": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.2.tgz",
-      "integrity": "sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==",
-      "dev": true
     },
     "walker": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --env=jest-environment-jsdom-sixteen",
     "eject": "react-scripts eject"
   },
   "proxy": "https://cov-clear.herokuapp.com",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.3.2",
+    "@testing-library/react": "^10.0.2",
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^24.0.0",
     "@types/jwt-decode": "^2.2.1",
@@ -60,6 +60,7 @@
     "@types/react-router-dom": "^5.1.3",
     "@types/theme-ui": "^0.3.1",
     "@types/yup": "^0.26.33",
+    "jest-environment-jsdom-sixteen": "^1.0.3",
     "typescript": "~3.7.2"
   }
 }

--- a/src/authentication/AuthenticatedRoute.test.tsx
+++ b/src/authentication/AuthenticatedRoute.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Router, Route } from 'react-router-dom';
 import { createMemoryHistory, History } from 'history';
-import { render, wait, screen } from '@testing-library/react';
+import { render, waitFor, screen } from '@testing-library/react';
 
 import { useAuthentication } from './context';
 import { AuthenticatedRoute } from './AuthenticatedRoute';
@@ -24,14 +24,14 @@ describe('Authenticated route', () => {
         <Route path="/login" exact>
           <h1>login page</h1>
         </Route>
-      </Router>,
+      </Router>
     );
   });
 
   it('lets you use the route when you are authenticated', async () => {
     mockAuthenticated();
     history.push('/private');
-    await wait(() => expect(screen.queryByText(/private/)).not.toBeNull());
+    await waitFor(() => expect(screen.queryByText(/private/)).not.toBeNull());
     expect(screen.queryByText(/login/)).toBeNull();
     expect(history.location.pathname).toBe('/private');
   });
@@ -39,7 +39,7 @@ describe('Authenticated route', () => {
   it('redirects you to login if you are not authenticated', async () => {
     mockSignedOut();
     history.push('/private');
-    await wait(() => expect(screen.queryByText(/login/)).not.toBeNull());
+    await waitFor(() => expect(screen.queryByText(/login/)).not.toBeNull());
     expect(screen.queryByText(/private/)).toBeNull();
     expect(history.location.pathname).toBe('/login');
     history.goBack();

--- a/src/authentication/LinkPage.test.tsx
+++ b/src/authentication/LinkPage.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Router, Route } from 'react-router-dom';
 import { createMemoryHistory, History } from 'history';
-import { render, wait } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 
 import { LinkPage } from './LinkPage';
 
@@ -49,14 +49,14 @@ describe('Link page', () => {
     });
 
     it('exchanges the link for the token and saves the token', async () => {
-      await wait(() => expect(saveToken).toHaveBeenCalledWith(mockToken));
+      await waitFor(() => expect(saveToken).toHaveBeenCalledWith(mockToken));
       expect(saveToken).toHaveBeenCalledTimes(1);
       expect(authenticate).toHaveBeenCalledWith(linkId, expect.anything());
       expect(authenticate).toHaveBeenCalledTimes(1);
     });
 
     it('replaces the route with the user page, removing it from history', async () => {
-      await wait(() =>
+      await waitFor(() =>
         expect(history.location.pathname).toBe('/users/f99c9790-f137-404f-9bf1-243d6e3e6f3e')
       );
       history.goBack();
@@ -71,7 +71,7 @@ describe('Link page', () => {
     });
 
     it('should redirect to the login page', async () => {
-      await wait(() => {
+      await waitFor(() => {
         expect(history.location.pathname).toBe('/login');
         expect(history.location.search).toBe('?invalid=true');
       });

--- a/src/identity/IdentityPage.test.tsx
+++ b/src/identity/IdentityPage.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Router, Route } from 'react-router-dom';
 import { createMemoryHistory, History } from 'history';
-import { wait, render, fireEvent, screen, queryByText } from '@testing-library/react';
+import { waitFor, render, fireEvent, screen, queryByText } from '@testing-library/react';
 
 import { IdentityPage } from './IdentityPage';
 
@@ -63,7 +63,7 @@ describe('Identity page', () => {
         <Route path="/users/:userId">
           <IdentityPage />
         </Route>
-      </Router>,
+      </Router>
     );
   });
 
@@ -74,51 +74,59 @@ describe('Identity page', () => {
     });
 
     it('shows their name and date of birth', async () => {
-      await wait(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
       expect(screen.queryByText(/01\/10\/1950/i)).toBeTruthy();
       expect(fetchUserMock).toHaveBeenCalledTimes(1);
     });
 
     it('loads and shows their sharing code in a qr code', async () => {
-      await wait(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
       expect(screen.queryByText(/Mock QRCode: mock-sharing-code/i)).toBeTruthy();
     });
 
     it('lets you switch to the tests tab', async () => {
-      await wait(() => expect(screen.queryByText(/Mock QRCode: mock-sharing-code/i)).toBeTruthy());
+      await waitFor(() =>
+        expect(screen.queryByText(/Mock QRCode: mock-sharing-code/i)).toBeTruthy()
+      );
       expect(screen.queryByText(/no tests yet/i)).toBeFalsy();
       fireEvent.click(screen.getByText(/tests/i));
-      await wait(() => expect(screen.queryByText(/no tests yet/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/no tests yet/i)).toBeTruthy());
       expect(screen.queryByText(/Mock QRCode: mock-sharing-code/i)).toBeFalsy();
       fireEvent.click(screen.getByText(/profile/i));
-      await wait(() => expect(screen.queryByText(/Mock QRCode: mock-sharing-code/i)).toBeTruthy());
+      await waitFor(() =>
+        expect(screen.queryByText(/Mock QRCode: mock-sharing-code/i)).toBeTruthy()
+      );
       expect(screen.queryByText(/no tests yet/i)).toBeFalsy();
     });
 
     it('shows all your tests on the tests tab', async () => {
-      await wait(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
       fetchTestsMock.mockImplementation(() => Promise.resolve([aTest(), anotherTest()]));
       fireEvent.click(screen.getByText(/tests/i));
-      await wait(() => expect(screen.queryAllByText(/mock test/i).length).toBe(2));
+      await waitFor(() => expect(screen.queryAllByText(/mock test/i).length).toBe(2));
       expect(screen.queryByText(/01\/10\/2005/i)).toBeTruthy();
       expect(screen.queryByText(/01\/11\/2005/i)).toBeTruthy();
     });
 
     it('lets you navigate with browser history', async () => {
-      await wait(() => expect(screen.queryByText(/Mock QRCode: mock-sharing-code/i)).toBeTruthy());
+      await waitFor(() =>
+        expect(screen.queryByText(/Mock QRCode: mock-sharing-code/i)).toBeTruthy()
+      );
       fireEvent.click(screen.getByText(/tests/i));
-      await wait(() => expect(screen.queryByText(/no tests yet/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/no tests yet/i)).toBeTruthy());
       expect(screen.queryByText(/Mock QRCode: mock-sharing-code/i)).toBeFalsy();
       history.goBack();
-      await wait(() => expect(screen.queryByText(/Mock QRCode: mock-sharing-code/i)).toBeTruthy());
+      await waitFor(() =>
+        expect(screen.queryByText(/Mock QRCode: mock-sharing-code/i)).toBeTruthy()
+      );
       expect(screen.queryByText(/no tests yet/i)).toBeFalsy();
       history.goForward();
-      await wait(() => expect(screen.queryByText(/no tests yet/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/no tests yet/i)).toBeTruthy());
       expect(screen.queryByText(/Mock QRCode: mock-sharing-code/i)).toBeFalsy();
     });
 
     it('lets you go to the scan page', async () => {
-      await wait(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
       expect(history.location.pathname).not.toBe('/scan');
       fireEvent.click(screen.getByText(/scan/i));
       expect(history.location.pathname).toBe('/scan');
@@ -142,27 +150,27 @@ describe('Identity page', () => {
 
     it('shows their name and date of birth', async () => {
       history.push('/users/mock-user');
-      await wait(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
       expect(screen.queryByText(/01\/10\/1950/i)).toBeTruthy();
       expect(fetchUserMock).toHaveBeenCalledTimes(1);
     });
 
     it('shows a special header that you are looking at another person', async () => {
       history.push('/users/mock-user-2');
-      await wait(() => expect(screen.queryByText(/patient profile/i)).not.toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/patient profile/i)).not.toBeTruthy());
       history.push('/users/mock-user');
-      await wait(() => expect(screen.queryByText(/patient profile/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/patient profile/i)).toBeTruthy());
     });
 
     it('does not show their QR code', async () => {
       history.push('/users/mock-user');
-      await wait(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
       expect(screen.queryByText(/Mock QRCode: mock-sharing-code/i)).not.toBeTruthy();
     });
 
     it('starts on the tests tab', async () => {
       history.push('/users/mock-user');
-      await wait(() => expect(screen.queryByText(/no tests yet/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/no tests yet/i)).toBeTruthy());
     });
   });
 
@@ -173,7 +181,7 @@ describe('Identity page', () => {
     });
 
     it('lets you fill your address with the correct information and then goes to your profile screen', async () => {
-      await wait(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
       expect(fetchUserMock).toHaveBeenCalledTimes(1);
       expect(screen.queryByText(/first middle last/i)).not.toBeTruthy();
 
@@ -183,7 +191,7 @@ describe('Identity page', () => {
       });
       fireEvent.click(screen.getByText(/register/i));
 
-      await wait(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
       expect(updateUserMock).toHaveBeenCalledWith(
         {
           ...aUser(),
@@ -193,96 +201,96 @@ describe('Identity page', () => {
           },
           creationTime: expect.any(String),
         },
-        expect.anything(),
+        expect.anything()
       );
     });
 
     it('does not let you update while it is loading', async () => {
-      await wait(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
       fillAddress();
       fireEvent.click(screen.getByText(/register/i));
       fireEvent.click(screen.getByText(/register/i));
       fireEvent.click(screen.getByText(/register/i));
       fireEvent.click(screen.getByText(/register/i));
       fireEvent.click(screen.getByText(/register/i));
-      await wait(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
       expect(updateUserMock).toHaveBeenCalledTimes(1);
     });
 
     it('lets you skip address line 2', async () => {
-      await wait(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
       fillAddress();
       fireEvent.click(screen.getByText(/register/i));
 
-      await wait(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
       expect(updateUserMock).toHaveBeenCalledWith(
         {
           ...aUser(),
           creationTime: expect.any(String),
         },
-        expect.anything(),
+        expect.anything()
       );
     });
 
     it('shows errors for missing line 1', async () => {
-      await wait(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
       fillAddress();
       fireEvent.change(screen.getByLabelText(/line 1/i), {
         target: { value: '  ' },
       });
       fireEvent.click(screen.getByText(/register/i));
-      await wait(() => expect(screen.queryByText(/fill line 1/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/fill line 1/i)).toBeTruthy());
       expect(updateUserMock).not.toHaveBeenCalled();
     });
 
     it('shows errors for missing city', async () => {
-      await wait(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
       fillAddress();
       fireEvent.change(screen.getByLabelText(/city/i), {
         target: { value: '' },
       });
       fireEvent.click(screen.getByText(/register/i));
-      await wait(() => expect(screen.queryByText(/fill the city/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/fill the city/i)).toBeTruthy());
       expect(updateUserMock).not.toHaveBeenCalled();
     });
 
     it('allows missing region', async () => {
-      await wait(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
       fillAddress();
       fireEvent.change(screen.getByLabelText(/state/i), {
         target: { value: '' },
       });
       fireEvent.click(screen.getByText(/register/i));
-      await wait(() => expect(screen.queryByText(/fill the state/i)).toBeFalsy());
+      await waitFor(() => expect(screen.queryByText(/fill the state/i)).toBeFalsy());
       expect(updateUserMock).toHaveBeenCalled();
     });
 
     it('shows errors for missing postcode', async () => {
-      await wait(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
       fillAddress();
       fireEvent.change(screen.getByLabelText(/postcode/i), {
         target: { value: '' },
       });
       fireEvent.click(screen.getByText(/register/i));
-      await wait(() => expect(screen.queryByText(/fill the postcode/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/fill the postcode/i)).toBeTruthy());
       expect(updateUserMock).not.toHaveBeenCalled();
     });
 
     it('does not currently let you change country', async () => {
-      await wait(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
       fillAddress();
       fireEvent.change(screen.getByLabelText(/country/i), {
         target: { value: 'Estonia' },
       });
       expect((screen.getByLabelText(/country/i) as HTMLInputElement).value).toBe('United Kingdom');
       fireEvent.click(screen.getByText(/register/i));
-      await wait(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
       expect(updateUserMock).toHaveBeenCalledWith(
         {
           ...aUser(),
           creationTime: expect.any(String),
         },
-        expect.anything(),
+        expect.anything()
       );
     });
   });
@@ -294,59 +302,59 @@ describe('Identity page', () => {
     });
 
     it('lets you fill your profile with the correct information and then goes to the next step', async () => {
-      await wait(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
       expect(fetchUserMock).toHaveBeenCalledTimes(1);
       expect(screen.queryByText(/2\/2/i)).not.toBeTruthy();
 
       fillProfileForm();
       fireEvent.click(screen.getByText(/next/i));
 
-      await wait(() => expect(screen.queryByText(/2\/2/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/2\/2/i)).toBeTruthy());
       expect(updateUserMock).toHaveBeenCalledWith(
         {
           ...aNewUserWithAProfile(),
           creationTime: expect.any(String),
         },
-        expect.anything(),
+        expect.anything()
       );
     });
 
     it('does not let you update while it is loading', async () => {
-      await wait(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
       fillProfileForm();
       fireEvent.click(screen.getByText(/next/i));
       fireEvent.click(screen.getByText(/next/i));
       fireEvent.click(screen.getByText(/next/i));
       fireEvent.click(screen.getByText(/next/i));
       fireEvent.click(screen.getByText(/next/i));
-      await wait(() => expect(screen.queryByText(/2\/2/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/2\/2/i)).toBeTruthy());
       expect(updateUserMock).toHaveBeenCalledTimes(1);
     });
 
     it('shows errors for missing first name', async () => {
-      await wait(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
       fillProfileForm();
       fireEvent.change(screen.getByLabelText(/first name/i), {
         target: { value: '' },
       });
       fireEvent.click(screen.getByText(/next/i));
-      await wait(() => expect(screen.queryByText(/fill your first name/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/fill your first name/i)).toBeTruthy());
       expect(updateUserMock).not.toHaveBeenCalled();
     });
 
     it('shows errors for missing last name', async () => {
-      await wait(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
       fillProfileForm();
       fireEvent.change(screen.getByLabelText(/last name/i), {
         target: { value: '' },
       });
       fireEvent.click(screen.getByText(/next/i));
-      await wait(() => expect(screen.queryByText(/fill your last name/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/fill your last name/i)).toBeTruthy());
       expect(updateUserMock).not.toHaveBeenCalled();
     });
 
     it('shows errors for missing sex', async () => {
-      await wait(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
       fireEvent.change(screen.getByLabelText(/first name/i), {
         target: { value: '  First Middle  ' },
       });
@@ -355,19 +363,19 @@ describe('Identity page', () => {
         target: { value: '1950-10-01' },
       });
       fireEvent.click(screen.getByText(/next/i));
-      await wait(() => expect(screen.queryByText(/select your legal sex/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/select your legal sex/i)).toBeTruthy());
       expect(updateUserMock).not.toHaveBeenCalled();
     });
 
     it('shows errors for missing date of birth', async () => {
-      await wait(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
       fireEvent.change(screen.getByLabelText(/first name/i), {
         target: { value: '  First Middle  ' },
       });
       fireEvent.change(screen.getByLabelText(/last name/i), { target: { value: '  Last  ' } });
       fireEvent.click(screen.getByLabelText(/female/i));
       fireEvent.click(screen.getByText(/next/i));
-      await wait(() => expect(screen.queryByText(/fill your date of birth/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/fill your date of birth/i)).toBeTruthy());
       expect(updateUserMock).not.toHaveBeenCalled();
     });
   });

--- a/src/scanning/ScanPage.test.tsx
+++ b/src/scanning/ScanPage.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Router, Route } from 'react-router-dom';
 import { createMemoryHistory, History } from 'history';
-import { wait, render, fireEvent, screen } from '@testing-library/react';
+import { waitFor, render, fireEvent, screen } from '@testing-library/react';
 import QRReader from 'react-qr-reader';
 
 import { ScanPage } from './ScanPage';
@@ -46,7 +46,7 @@ describe('Identity page', () => {
     render(
       <Router history={history}>
         <ScanPage />
-      </Router>,
+      </Router>
     );
   });
 
@@ -81,4 +81,3 @@ describe('Identity page', () => {
     expect(screen.queryByText(/incorrect/i)).not.toBeTruthy();
   });
 });
-

--- a/src/testing/AddTestPage.test.tsx
+++ b/src/testing/AddTestPage.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Router, Route } from 'react-router-dom';
 import { createMemoryHistory, History } from 'history';
-import { wait, render, screen, fireEvent } from '@testing-library/react';
+import { waitFor, render, screen, fireEvent } from '@testing-library/react';
 
 import { AddTestPage } from './AddTestPage';
 
@@ -52,7 +52,7 @@ describe('Test adding page', () => {
   describe('when testing yourself', () => {
     it('lets you add a test result', async () => {
       history.push('/users/mock-user/add-test');
-      await wait(() => expect(screen.queryByText(/test type/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/test type/i)).toBeTruthy());
       expect(createTestMock).not.toHaveBeenCalled();
       fireEvent.change(screen.queryByLabelText(/test type/i), {
         target: { value: aTestType().id },
@@ -68,7 +68,7 @@ describe('Test adding page', () => {
         target: { value: 'some free text notes' },
       });
       fireEvent.click(screen.queryByText(/save/i));
-      await wait(() => expect(history.location.pathname).toBe('/users/mock-user/tests'));
+      await waitFor(() => expect(history.location.pathname).toBe('/users/mock-user/tests'));
       expect(createTestMock).toHaveBeenCalledTimes(1);
       expect(createTestMock).toHaveBeenCalledWith(
         'mock-user',
@@ -89,7 +89,7 @@ describe('Test adding page', () => {
 
     it('does not let you select non-permitted test types', async () => {
       history.push('/users/mock-user/add-test');
-      await wait(() => expect(screen.queryByText(/test type/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/test type/i)).toBeTruthy());
       expect(screen.queryByText(/proper mock test/i)).toBeTruthy();
       expect(screen.queryByText(/simple mock test/i)).toBeTruthy();
       expect(screen.queryByText(/non-permitted mock test/i)).toBeFalsy();
@@ -104,34 +104,34 @@ describe('Test adding page', () => {
         Promise.resolve([aTestType(), aNonPermittedTestType()])
       );
       history.push('/users/mock-user/add-test');
-      await wait(() => expect(screen.queryByText(/boolean/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/boolean/i)).toBeTruthy());
       expect(screen.queryByText(/test type/i)).not.toBeTruthy();
     });
 
     it('shows descriptions of properties if they exist', async () => {
       history.push('/users/mock-user/add-test');
-      await wait(() => expect(screen.queryByText(/this is a description/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/this is a description/i)).toBeTruthy());
     });
   });
 
   describe('when testing someone else', () => {
     it('shows you a special header to show you are looking at a patient', async () => {
       history.push('/users/mock-user/add-test');
-      await wait(() => expect(screen.queryByText(/test type/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/test type/i)).toBeTruthy());
       expect(screen.queryByText(/patient profile/i)).not.toBeTruthy();
       history.push('/users/mock-patient/add-test');
-      await wait(() => expect(screen.queryByText(/patient profile/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/patient profile/i)).toBeTruthy());
     });
 
     it('asks you to confirm their identity and then submits the test', async () => {
       history.push('/users/mock-patient/add-test');
-      await wait(() => expect(screen.queryByText(/test type/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/test type/i)).toBeTruthy());
       fireEvent.change(screen.queryByLabelText(/test type/i), {
         target: { value: aSimpleTestType() },
       });
       fireEvent.click(screen.queryByLabelText(/boolean field/i));
       fireEvent.click(screen.queryByText(/save/i));
-      await wait(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
+      await waitFor(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
       expect(createTestMock).not.toHaveBeenCalled();
       expect(history.location.pathname).toBe('/users/mock-patient/add-test/confirm');
       expect(screen.queryByText(/01\/10\/1950/i)).toBeTruthy();


### PR DESCRIPTION
Version 10 introduces the `waitFor` async function and deprecates every `waitX` except `waitForElementToBeRemoved`. Although `wait` was not removed, merely deprecated, it has been changed to `waitFor` to remove deprecation messages from tests.

[@testing-library/react releases](https://github.com/testing-library/react-testing-library/releases)