### PR TITLE
Add permission protection to AuthenticatedRoute

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,9 @@ const App = () => {
       <AuthenticatedRoute path="/scan" exact>
         <ScanPage />
       </AuthenticatedRoute>
+      <AuthenticatedRoute path="/admin/create-users" exact requiredPermission="BULK_CREATE_USERS">
+        Create users
+      </AuthenticatedRoute>
       <Route path="*">
         <NotFoundPage />
       </Route>

--- a/src/authentication/AuthenticatedRoute.tsx
+++ b/src/authentication/AuthenticatedRoute.tsx
@@ -1,23 +1,48 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { RouteProps, Redirect, Route } from 'react-router-dom';
-import { useAuthentication } from './context';
 
-const AuthenticatedRouteRedirecter = ({ children }: { children: React.ReactNode }) => {
-  const { token } = useAuthentication();
+import { useAuthentication } from './context';
+import { NotFoundPage } from '../staticPages';
+
+interface AuthenticatedRouteRedirecterProps {
+  requiredPermission?: string;
+}
+
+const AuthenticatedRouteRedirecter: FC<AuthenticatedRouteRedirecterProps> = ({
+  requiredPermission,
+  children,
+}) => {
+  const { token, hasPermission } = useAuthentication();
   const authenticated = !!token;
 
   if (!authenticated) {
     return <Redirect to="/login" />;
   }
 
+  if (requiredPermission && !hasPermission(requiredPermission)) {
+    return <NotFoundPage />;
+  }
+
   return <>{children}</>;
 };
 
-export const AuthenticatedRoute = ({ children, ...rest }: RouteProps) => {
+interface AuthenticatedRouteProps extends RouteProps {
+  requiredPermission?: string;
+}
+
+export const AuthenticatedRoute: FC<AuthenticatedRouteProps> = ({
+  requiredPermission,
+  children,
+  ...rest
+}) => {
   return (
     <Route
       {...rest}
-      render={() => <AuthenticatedRouteRedirecter>{children}</AuthenticatedRouteRedirecter>}
+      render={() => (
+        <AuthenticatedRouteRedirecter requiredPermission={requiredPermission}>
+          {children}
+        </AuthenticatedRouteRedirecter>
+      )}
     />
   );
 };


### PR DESCRIPTION
## Context

We will be adding a bulk user creation page, an admin page to create users with certain roles in bulk. As that action will require a certain permission (e.g., `BULK_CREATE_USERS`), we should also make the route protected by this permission.

## Changes

* an optional `requiredPermission` prop is added to `AuthenticatedRoute`
* a dummy `/admin/create-users` page is exposed to users with the permission `BULK_CREATE_USERS`

## Considerations

As permissions are more authorization-related rather than authentication-related, should we rename the component to `ProtectedRoute`, for example (at some point)? Kept it the same for now to reduce the number of changes and to align with the hook (`useAuthentication` does provide us the `hasPermissions` function).