### PR TITLE
Add how it works page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { NotFoundPage } from './staticPages';
 import { ScanPage } from './scanning';
 import { IdentityPage } from './identity';
 import { AddTestPage, TestDetailPage } from './testing';
+import { HowItWorksPage } from './help';
 import { BulkUserCreationPage } from './admin';
 
 const App = () => {
@@ -51,9 +52,14 @@ const App = () => {
       <AuthenticatedRoute path="/scan" exact>
         <ScanPage />
       </AuthenticatedRoute>
+      <AuthenticatedRoute path="/how-it-works" exact>
+        <HowItWorksPage />
+      </AuthenticatedRoute>
+
       <AuthenticatedRoute path="/admin/create-users" exact requiredPermission="BULK_CREATE_USERS">
         <BulkUserCreationPage />
       </AuthenticatedRoute>
+
       <Route path="*">
         <NotFoundPage />
       </Route>

--- a/src/help/HowItWorksPage.tsx
+++ b/src/help/HowItWorksPage.tsx
@@ -1,0 +1,25 @@
+import React, { FC } from 'react';
+import { Link, LinkProps } from 'react-router-dom';
+import { Container, Heading, Text, Button, ButtonProps } from 'theme-ui';
+
+const LinkButton = Button as React.FC<ButtonProps & LinkProps>;
+
+export const HowItWorksPage: FC = () => {
+  return (
+    <Container variant="page">
+      <Heading as="h1" mb={4}>
+        How it works
+      </Heading>
+
+      <Text mb={4}>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Non delectus minus temporibus
+        distinctio beatae soluta debitis voluptatum hic suscipit odit ducimus tempore quasi ad dicta
+        nisi deleniti facere, dolore assumenda?
+      </Text>
+
+      <LinkButton as={Link} to="/" variant="block">
+        Continue
+      </LinkButton>
+    </Container>
+  );
+};

--- a/src/help/index.ts
+++ b/src/help/index.ts
@@ -1,0 +1,1 @@
+export * from './HowItWorksPage';

--- a/src/identity/IdentityPage.test.tsx
+++ b/src/identity/IdentityPage.test.tsx
@@ -355,6 +355,13 @@ describe('Identity page', () => {
         expect.anything()
       );
     });
+
+    it('redirects to how it works after filling address', async () => {
+      await waitFor(() => expect(screen.queryByText(/enter your details/i)).toBeTruthy());
+      fillAddress();
+      fireEvent.click(screen.getByText(/register/i));
+      await waitFor(() => expect(history.location.pathname).toBe('/how-it-works'));
+    });
   });
 
   describe('when filling profile', () => {
@@ -582,5 +589,5 @@ function secondsFromNow(seconds: number): Date {
 }
 
 function nextTick() {
-  return new Promise(resolve => setImmediate(resolve));
+  return new Promise((resolve) => setImmediate(resolve));
 }

--- a/src/identity/IdentityPage.tsx
+++ b/src/identity/IdentityPage.tsx
@@ -20,6 +20,7 @@ import {
   Redirect,
   Link,
   LinkProps,
+  useHistory,
 } from 'react-router-dom';
 import { format } from 'date-fns';
 
@@ -49,6 +50,7 @@ export const IdentityPage = () => {
     url,
     params: { userId },
   } = useRouteMatch();
+  const history = useHistory();
   const { user, update: updateUser } = useUser(userId);
   const { userId: authenticatedUserId } = useAuthentication();
   const isOwnUser = userId === authenticatedUserId;
@@ -61,8 +63,9 @@ export const IdentityPage = () => {
     return updateUser({ ...user!, profile });
   }
 
-  function createAddress(address: Address) {
-    return updateUser({ ...user!, address });
+  async function createAddress(address: Address) {
+    await updateUser({ ...user!, address });
+    return history.push('/how-it-works');
   }
 
   if (!user.profile) {
@@ -136,4 +139,3 @@ export const IdentityPage = () => {
     </>
   );
 };
-


### PR DESCRIPTION
## Context

We want to show a _how it works_ interstitial in the app to explain what it does to users.

## Changes

A dummy _how it works_ page has been added, as we're still figuring out the content of the page.

The page will be shown only after filling in the address, and pressing the CTA on that page will redirect back to root.

To make it more flexible, we're also exposing it under `/how-it-works`.

## Screenshots

TODO, when we have some meaningful copy.