### PR TITLE
Quick fix for test drilldown page

### DIFF
--- a/src/testing/TestDetailPage.test.tsx
+++ b/src/testing/TestDetailPage.test.tsx
@@ -5,13 +5,14 @@ import { render, screen, waitFor } from '@testing-library/react';
 
 import { TestDetailPage } from './TestDetailPage';
 
-import { fetchTest, Test, TestType } from '../api';
+import { fetchTest, Test, TestType, fetchTestTypes } from '../api';
 import { useAuthentication } from '../authentication';
 
 jest.mock('../api');
 jest.mock('../authentication');
 
 const fetchTestMock = fetchTest as jest.MockedFunction<typeof fetchTest>;
+const fetchTestTypesMock = fetchTestTypes as jest.MockedFunction<typeof fetchTestTypes>;
 const useAuthenticationMock = useAuthentication as jest.MockedFunction<typeof useAuthentication>;
 
 describe('Test detail page', () => {
@@ -27,6 +28,7 @@ describe('Test detail page', () => {
       hasPermission: (key: string) => key === 'mock-permission',
     }));
     fetchTestMock.mockImplementation(() => Promise.resolve(aTest()));
+    fetchTestTypesMock.mockImplementation(() => Promise.resolve([aTestType()]));
 
     render(
       <Router history={history}>

--- a/src/testing/TestDetailPage.tsx
+++ b/src/testing/TestDetailPage.tsx
@@ -3,29 +3,32 @@ import { useParams } from 'react-router-dom';
 import { Container, Heading, Spinner, Text, Divider, Flex, Box } from 'theme-ui';
 import { format } from 'date-fns';
 
-import { useTest } from '../resources';
+import { useTest, useTestTypes } from '../resources';
 import { FieldValue } from '../api';
-
 import { InterpretationBadge } from './InterpretationBadge';
 
 export const TestDetailPage = () => {
   const { testId } = useParams<{ testId: string }>();
+  const { testTypes } = useTestTypes();
   const { test, loading } = useTest(testId);
   if (loading || !test) {
     return <Spinner variant="spinner.main" />;
   }
-  const testResults = test?.results
-    ? Object.entries(test.testType.resultsSchema.properties).map(([key, value]) => {
-        return {
-          label: value.title,
-          value: test?.results?.details[key],
-        };
-      })
-    : [];
+  const testType = testTypes.find(type => type.id === test?.testType.id);
+  const testResults =
+    test?.results && testType
+      ? Object.entries(testType.resultsSchema.properties).map(([key, value]) => {
+          return {
+            label: value.title,
+            value: test?.results?.details[key],
+          };
+        })
+      : [];
   testResults.unshift({
     label: 'Test type',
-    value: test.testType.name,
+    value: testType?.name,
   });
+
   return (
     <Container variant="page">
       <Heading as="h1" mb={2}>


### PR DESCRIPTION
We don't include `resultsSchema` inside the test type, adding this as a temporary workaround.