### PR TITLE
Move Container to App level

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,44 +22,51 @@ const App = () => {
   const { userId } = useAuthentication();
 
   return (
-    <Container variant="page">
-      <Switch>
-        <Route
-          path="/"
-          exact
-          render={() => {
-            if (userId) {
-              return <Redirect to={`/users/${userId}`} />;
-            }
-            return <Redirect to="/login" />;
-          }}
-        />
-        <Route path="/login" exact>
-          <LoginPage />
-        </Route>
-        <Route path="/link/:linkId" exact>
-          <LinkPage />
-        </Route>
-        <AuthenticatedRoute path="/users/:userId/add-test">
-          <AddTestPage />
-        </AuthenticatedRoute>
-        <AuthenticatedRoute path="/users/:userId">
-          <IdentityPage />
-        </AuthenticatedRoute>
-        <AuthenticatedRoute path="/tests/:testId" exact>
-          <TestDetailPage />
-        </AuthenticatedRoute>
-        <AuthenticatedRoute path="/scan" exact>
-          <ScanPage />
-        </AuthenticatedRoute>
-        <AuthenticatedRoute path="/admin/create-users" exact requiredPermission="BULK_CREATE_USERS">
-          <BulkUserCreationPage />
-        </AuthenticatedRoute>
-        <Route path="*">
-          <NotFoundPage />
-        </Route>
-      </Switch>
-    </Container>
+    <Switch>
+      <AuthenticatedRoute path="/scan" exact>
+        <ScanPage />
+      </AuthenticatedRoute>
+
+      <Container variant="page">
+        <Switch>
+          <Route
+            path="/"
+            exact
+            render={() => {
+              if (userId) {
+                return <Redirect to={`/users/${userId}`} />;
+              }
+              return <Redirect to="/login" />;
+            }}
+          />
+          <Route path="/login" exact>
+            <LoginPage />
+          </Route>
+          <Route path="/link/:linkId" exact>
+            <LinkPage />
+          </Route>
+          <AuthenticatedRoute path="/users/:userId/add-test">
+            <AddTestPage />
+          </AuthenticatedRoute>
+          <AuthenticatedRoute path="/users/:userId">
+            <IdentityPage />
+          </AuthenticatedRoute>
+          <AuthenticatedRoute path="/tests/:testId" exact>
+            <TestDetailPage />
+          </AuthenticatedRoute>
+          <AuthenticatedRoute
+            path="/admin/create-users"
+            exact
+            requiredPermission="BULK_CREATE_USERS"
+          >
+            <BulkUserCreationPage />
+          </AuthenticatedRoute>
+          <Route path="*">
+            <NotFoundPage />
+          </Route>
+        </Switch>
+      </Container>
+    </Switch>
   );
 };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BrowserRouter, Switch, Route, Redirect } from 'react-router-dom';
-import { ThemeProvider } from 'theme-ui';
+import { ThemeProvider, Container } from 'theme-ui';
 
 import {
   LoginPage,
@@ -22,42 +22,44 @@ const App = () => {
   const { userId } = useAuthentication();
 
   return (
-    <Switch>
-      <Route
-        path="/"
-        exact
-        render={() => {
-          if (userId) {
-            return <Redirect to={`/users/${userId}`} />;
-          }
-          return <Redirect to="/login" />;
-        }}
-      />
-      <Route path="/login" exact>
-        <LoginPage />
-      </Route>
-      <Route path="/link/:linkId" exact>
-        <LinkPage />
-      </Route>
-      <AuthenticatedRoute path="/users/:userId/add-test">
-        <AddTestPage />
-      </AuthenticatedRoute>
-      <AuthenticatedRoute path="/users/:userId">
-        <IdentityPage />
-      </AuthenticatedRoute>
-      <AuthenticatedRoute path="/tests/:testId" exact>
-        <TestDetailPage />
-      </AuthenticatedRoute>
-      <AuthenticatedRoute path="/scan" exact>
-        <ScanPage />
-      </AuthenticatedRoute>
-      <AuthenticatedRoute path="/admin/create-users" exact requiredPermission="BULK_CREATE_USERS">
-        <BulkUserCreationPage />
-      </AuthenticatedRoute>
-      <Route path="*">
-        <NotFoundPage />
-      </Route>
-    </Switch>
+    <Container variant="page">
+      <Switch>
+        <Route
+          path="/"
+          exact
+          render={() => {
+            if (userId) {
+              return <Redirect to={`/users/${userId}`} />;
+            }
+            return <Redirect to="/login" />;
+          }}
+        />
+        <Route path="/login" exact>
+          <LoginPage />
+        </Route>
+        <Route path="/link/:linkId" exact>
+          <LinkPage />
+        </Route>
+        <AuthenticatedRoute path="/users/:userId/add-test">
+          <AddTestPage />
+        </AuthenticatedRoute>
+        <AuthenticatedRoute path="/users/:userId">
+          <IdentityPage />
+        </AuthenticatedRoute>
+        <AuthenticatedRoute path="/tests/:testId" exact>
+          <TestDetailPage />
+        </AuthenticatedRoute>
+        <AuthenticatedRoute path="/scan" exact>
+          <ScanPage />
+        </AuthenticatedRoute>
+        <AuthenticatedRoute path="/admin/create-users" exact requiredPermission="BULK_CREATE_USERS">
+          <BulkUserCreationPage />
+        </AuthenticatedRoute>
+        <Route path="*">
+          <NotFoundPage />
+        </Route>
+      </Switch>
+    </Container>
   );
 };
 

--- a/src/admin/BulkUserCreationPage.tsx
+++ b/src/admin/BulkUserCreationPage.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { Box, Label, Heading, Container, Button, Text, Textarea, Alert, Select } from 'theme-ui';
+import { Box, Label, Heading, Button, Text, Textarea, Alert, Select } from 'theme-ui';
 import { useFormik } from 'formik';
 import * as yup from 'yup';
 
@@ -43,7 +43,7 @@ const BulkUserCreationPage: FC = () => {
   });
 
   return (
-    <Container variant="page">
+    <>
       <Heading as="h1" mb={4}>
         Create users
       </Heading>
@@ -84,13 +84,23 @@ const BulkUserCreationPage: FC = () => {
       </AnyBox>
 
       {createdUsers.length > 0 && (
-        <Alert variant="success" mb={2}>{createdUsers.length} user(s) successfully created.</Alert>
+        <Alert variant="success" mb={2}>
+          {createdUsers.length} user(s) successfully created.
+        </Alert>
       )}
 
-      {errorLoadingRoles && <Alert variant="error" mb={2}>{errorLoadingRoles.message}</Alert>}
+      {errorLoadingRoles && (
+        <Alert variant="error" mb={2}>
+          {errorLoadingRoles.message}
+        </Alert>
+      )}
 
-      {errorCreatingUsers && <Alert variant="error" mb={2}>{errorCreatingUsers.message}</Alert>}
-    </Container>
+      {errorCreatingUsers && (
+        <Alert variant="error" mb={2}>
+          {errorCreatingUsers.message}
+        </Alert>
+      )}
+    </>
   );
 };
 

--- a/src/authentication/LoginPage.tsx
+++ b/src/authentication/LoginPage.tsx
@@ -1,17 +1,7 @@
 import React, { useState } from 'react';
 import { useFormik } from 'formik';
 import * as yup from 'yup';
-import {
-  Container,
-  Label,
-  Input,
-  Button,
-  Text,
-  Heading,
-  Box,
-  Alert,
-  Link as ThemeUiLink,
-} from 'theme-ui';
+import { Label, Input, Button, Text, Heading, Box, Alert, Link as ThemeUiLink } from 'theme-ui';
 
 import { createMagicLink } from '../api';
 
@@ -29,7 +19,7 @@ export const LoginPage = () => {
   const invalidLink = urlParams.get('invalid');
 
   return (
-    <Container variant="page">
+    <>
       {invalidLink && !submitted && (
         <Alert variant="secondary" mb={4}>
           That link wasn't valid, please request a new one.
@@ -56,7 +46,7 @@ export const LoginPage = () => {
       >
         Privacy
       </ThemeUiLink>
-    </Container>
+    </>
   );
 };
 

--- a/src/identity/IdentityPage.tsx
+++ b/src/identity/IdentityPage.tsx
@@ -6,7 +6,6 @@ import {
   Heading,
   NavLink as ThemeUiNavLink,
   Flex,
-  Container,
   NavLinkProps,
 } from 'theme-ui';
 import {
@@ -62,30 +61,30 @@ export const IdentityPage = () => {
 
   if (!user.profile) {
     return (
-      <Container variant="page">
+      <>
         <Heading as="h1" mb={5}>
           Enter your details <Small>1/2</Small>
         </Heading>
         <ProfileForm onComplete={createProfile} />
-      </Container>
+      </>
     );
   }
 
   if (!user.address) {
     return (
-      <Container variant="page">
+      <>
         <Heading as="h1" mb={5}>
           Enter your details <Small>2/2</Small>
         </Heading>
         <AddressForm onComplete={createAddress} />
-      </Container>
+      </>
     );
   }
 
   return (
     <>
       {!isOwnUser ? <ViewingOtherProfileHeader /> : null}
-      <Container variant="page" pt={isOwnUser ? undefined : 4}>
+      <Box pt={isOwnUser ? undefined : 4}>
         <Heading as="h1" mb={3}>
           {user.profile.firstName} {user.profile.lastName}
         </Heading>
@@ -133,7 +132,7 @@ export const IdentityPage = () => {
             )
           }
         />
-      </Container>
+      </Box>
     </>
   );
 };

--- a/src/identity/ProfileForm.tsx
+++ b/src/identity/ProfileForm.tsx
@@ -77,7 +77,7 @@ export const ProfileForm = ({ onComplete }: { onComplete: (profile: Profile) => 
           id="identity-dateOfBirth"
           type="date"
           {...form.getFieldProps('dateOfBirth')}
-          sx={{ minHeight: '42px' }}
+          sx={{ minHeight: '42px', fontFamily: 'inherit' }}
         />
         {fieldError('dateOfBirth')}
       </Box>

--- a/src/scanning/ScanPage.tsx
+++ b/src/scanning/ScanPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Text, Container, Heading, Box, Spinner } from 'theme-ui';
+import { Text, Heading, Box, Spinner } from 'theme-ui';
 import QrReader from 'react-qr-reader';
 import { useHistory } from 'react-router-dom';
 import { createAccessPass } from '../api';
@@ -39,7 +39,7 @@ export const ScanPage = () => {
   }, [error]);
 
   return (
-    <Container sx={{ maxWidth: '600px' }}>
+    <Box sx={{ maxWidth: '600px' }}>
       <QrReader
         delay={100}
         style={{ width: '100%' }}
@@ -64,6 +64,6 @@ export const ScanPage = () => {
         <Text mb={3}>Point your camera at the person's sharing code</Text>
         {loading ? <Spinner mx="auto" sx={{ display: 'block' }} /> : null}
       </Box>
-    </Container>
+    </Box>
   );
 };

--- a/src/staticPages.tsx
+++ b/src/staticPages.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Link, LinkProps } from 'react-router-dom';
-import { Heading, Button, ButtonProps, Image, Container } from 'theme-ui';
+import { Heading, Button, ButtonProps, Image } from 'theme-ui';
 
 import balloonIllustration from './illustrations/balloons.svg';
 
 const NavButton = Button as React.FC<ButtonProps & LinkProps>;
 export const NotFoundPage = () => (
-  <Container variant="page">
+  <>
     <Heading as="h1" mb={5}>
       This page doesn't exist
     </Heading>
@@ -14,5 +14,5 @@ export const NotFoundPage = () => (
     <NavButton as={Link} variant="block" to="/">
       Go to the start page
     </NavButton>
-  </Container>
+  </>
 );

--- a/src/testing/AddTestPage.tsx
+++ b/src/testing/AddTestPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Heading, Select, Label, Container } from 'theme-ui';
+import { Heading, Select, Label, Box } from 'theme-ui';
 
 import { CreateTestCommand, createTest } from '../api';
 import { Redirect, useHistory, useRouteMatch } from 'react-router-dom';
@@ -22,7 +22,7 @@ export const AddTestPage = () => {
   const { token, userId: ownUserId } = useAuthentication();
   const isOwnUser = userId === ownUserId;
   const { permittedTestTypes } = useTestTypes();
-  const selectedTestType = permittedTestTypes.find(type => type.id === selectedTestTypeId);
+  const selectedTestType = permittedTestTypes.find((type) => type.id === selectedTestTypeId);
   const confirmPageMatch = useRouteMatch(`${url}/confirm`);
 
   useEffect(() => {
@@ -59,9 +59,9 @@ export const AddTestPage = () => {
     return (
       <>
         {!isOwnUser ? <ViewingOtherProfileHeader /> : null}
-        <Container variant="page" pt={isOwnUser ? undefined : 4}>
+        <Box pt={isOwnUser ? undefined : 4}>
           <ConfirmIdentity userId={userId} loading={submitting} onConfirm={handleConfirmIdentity} />
-        </Container>
+        </Box>
       </>
     );
   }
@@ -69,7 +69,7 @@ export const AddTestPage = () => {
   return (
     <>
       {!isOwnUser ? <ViewingOtherProfileHeader /> : null}
-      <Container variant="page" pt={isOwnUser ? undefined : 4}>
+      <Box pt={isOwnUser ? undefined : 4}>
         <Heading as="h1" mb={5}>
           Enter new test result
         </Heading>
@@ -79,11 +79,11 @@ export const AddTestPage = () => {
             <Select
               id="test-type"
               value={selectedTestTypeId}
-              onChange={event => setSelectedTestTypeId(event.target.value)}
+              onChange={(event) => setSelectedTestTypeId(event.target.value)}
               required
               mb={4}
             >
-              {permittedTestTypes.map(type => (
+              {permittedTestTypes.map((type) => (
                 <option key={type.id} value={type.id}>
                   {type.name}
                 </option>
@@ -98,7 +98,7 @@ export const AddTestPage = () => {
             onComplete={handleSubmit}
           />
         ) : null}
-      </Container>
+      </Box>
     </>
   );
 };

--- a/src/testing/TestDetailPage.tsx
+++ b/src/testing/TestDetailPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import { Container, Heading, Spinner, Text, Divider, Flex, Box } from 'theme-ui';
+import { Heading, Spinner, Text, Divider, Flex, Box } from 'theme-ui';
 import { format } from 'date-fns';
 
 import { useTest, useTestTypes } from '../resources';
@@ -14,7 +14,7 @@ export const TestDetailPage = () => {
   if (loading || !test) {
     return <Spinner variant="spinner.main" />;
   }
-  const testType = testTypes.find(type => type.id === test?.testType.id);
+  const testType = testTypes.find((type) => type.id === test?.testType.id);
   const testResults =
     test?.results && testType
       ? Object.entries(testType.resultsSchema.properties).map(([key, value]) => {
@@ -30,7 +30,7 @@ export const TestDetailPage = () => {
   });
 
   return (
-    <Container variant="page">
+    <>
       <Heading as="h1" mb={2}>
         Test result
       </Heading>
@@ -65,7 +65,7 @@ export const TestDetailPage = () => {
           {test.results.notes}
         </>
       ) : null}
-    </Container>
+    </>
   );
 };
 


### PR DESCRIPTION
## Context

`Container variant="page"` is currently repeated on all pages, as these contain the styles for all pages. In addition to being repetitive, it means we're not able to add components aligning to that variant on the `App` level, e.g., a signout button.

## Changes

`Container` is replaced with fragments and `Box`es and the page variant defining `Container` is moved to `App`.

As a side change, the input with type `date` has been made to use the same font as the other inputs:
![image](https://user-images.githubusercontent.com/5443561/78862598-676e5100-7a40-11ea-813b-b6bf0ceb0af4.png)

![image](https://user-images.githubusercontent.com/5443561/78862605-6b01d800-7a40-11ea-8f44-e46c247e748f.png)

Visually, everything else remains identical (went through all the pages).