### PR TITLE
Rename broken translation key

### DIFF
--- a/src/identity/AddressForm.tsx
+++ b/src/identity/AddressForm.tsx
@@ -84,7 +84,7 @@ export const AddressForm = ({ onComplete }: { onComplete: (address: Address) => 
       </Box>
 
       <Button variant="block" type="submit" disabled={form.isSubmitting}>
-        <Message>addressForm.register</Message>
+        <Message>addressForm.button</Message>
       </Button>
     </AnyBox>
   );


### PR DESCRIPTION
## Context

The address form's CTA is currently showing the translation key, as it's using a different key than defined in the translation file.

## Changes

The key used is unified.