### PR TITLE
Support multiple required permissions for authenticated routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,7 +62,11 @@ const App = () => {
       <AuthenticatedRoute path="/scan" exact>
         <ScanPage />
       </AuthenticatedRoute>
-      <AuthenticatedRoute path="/admin/create-users" exact requiredPermission="BULK_CREATE_USERS">
+      <AuthenticatedRoute
+        path="/admin/create-users"
+        exact
+        requiredPermissions={['BULK_CREATE_USERS']}
+      >
         <BulkUserCreationPage />
       </AuthenticatedRoute>
       <Route path="*">

--- a/src/authentication/AuthenticatedRoute.test.tsx
+++ b/src/authentication/AuthenticatedRoute.test.tsx
@@ -23,7 +23,11 @@ describe('Authenticated route', () => {
           <h1>private page</h1>
         </AuthenticatedRoute>
 
-        <AuthenticatedRoute path="/protected" requiredPermission="MOCK_PERMISSION" exact>
+        <AuthenticatedRoute
+          path="/protected"
+          requiredPermissions={['A_PERMISSION', 'ANOTHER_PERMISSION']}
+          exact
+        >
           <h1>protected page</h1>
         </AuthenticatedRoute>
 
@@ -52,15 +56,15 @@ describe('Authenticated route', () => {
     expect(history.location.pathname).toBe('/');
   });
 
-  it('displays not found page when user does not have the required permission', async () => {
-    mockAuthenticated([]);
+  it('displays not found page when user is missing any of the required permissions', async () => {
+    mockAuthenticated(['A_PERMISSION']);
     history.push('/protected');
     await waitFor(() => expect(screen.getByText(/doesn't exist/)).toBeInTheDocument());
     expect(screen.queryByText(/protected/)).toBeNull();
   });
 
-  it('displays protected content when user does has the required permission', async () => {
-    mockAuthenticated(['MOCK_PERMISSION']);
+  it('displays protected content when user has all the required permissions', async () => {
+    mockAuthenticated(['A_PERMISSION', 'ANOTHER_PERMISSION']);
     history.push('/protected');
     await waitFor(() => expect(screen.getByText(/protected/)).toBeInTheDocument());
     expect(screen.queryByText(/doesn't exist/)).toBeNull();

--- a/src/authentication/AuthenticatedRoute.tsx
+++ b/src/authentication/AuthenticatedRoute.tsx
@@ -5,21 +5,21 @@ import { useAuthentication } from './context';
 import { NotFoundPage } from '../staticPages';
 
 interface AuthenticatedRouteRedirecterProps {
-  requiredPermission?: string;
+  requiredPermissions?: string[];
 }
 
 const AuthenticatedRouteRedirecter: FC<AuthenticatedRouteRedirecterProps> = ({
-  requiredPermission,
+  requiredPermissions,
   children,
 }) => {
-  const { token, hasPermission } = useAuthentication();
+  const { token, hasPermission: userHasPermission } = useAuthentication();
   const authenticated = !!token;
 
   if (!authenticated) {
     return <Redirect to="/login" />;
   }
 
-  if (requiredPermission && !hasPermission(requiredPermission)) {
+  if (requiredPermissions && !requiredPermissions.every(userHasPermission)) {
     return <NotFoundPage />;
   }
 
@@ -27,11 +27,11 @@ const AuthenticatedRouteRedirecter: FC<AuthenticatedRouteRedirecterProps> = ({
 };
 
 interface AuthenticatedRouteProps extends RouteProps {
-  requiredPermission?: string;
+  requiredPermissions?: string[];
 }
 
 export const AuthenticatedRoute: FC<AuthenticatedRouteProps> = ({
-  requiredPermission,
+  requiredPermissions,
   children,
   ...rest
 }) => {
@@ -39,7 +39,7 @@ export const AuthenticatedRoute: FC<AuthenticatedRouteProps> = ({
     <Route
       {...rest}
       render={() => (
-        <AuthenticatedRouteRedirecter requiredPermission={requiredPermission}>
+        <AuthenticatedRouteRedirecter requiredPermissions={requiredPermissions}>
           {children}
         </AuthenticatedRouteRedirecter>
       )}


### PR DESCRIPTION
## Context

We're creating a _add test for identifier page_, which requires 2 permissions to function, therefore the route should be restricted by both of those permissions.

The current `AuthenticatedRoute` interface only supports one `requiredPermission`.

## Changes

`AuthenticatedRoute` `requiredPermission` prop is changed to `requiredPermissions`.