### PR TITLE
Move to a single login page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,8 +4,7 @@ import { ThemeProvider, Spinner } from 'theme-ui';
 import { Provider as TranslationProvider } from 'retranslate';
 
 import {
-  MagicLinkLoginPage,
-  EstonianIdLoginPage,
+  LoginPage,
   AuthenticationCallbackPage,
   Provider as AuthenticationProvider,
   AuthenticatedRoute,
@@ -44,10 +43,7 @@ const App = () => {
         }}
       />
       <Route path="/login" exact>
-        <MagicLinkLoginPage />
-      </Route>
-      <Route path="/estonian-id-login" exact>
-        <EstonianIdLoginPage />
+        <LoginPage />
       </Route>
       <Route path="/authentication-callback" exact>
         <AuthenticationCallbackPage />

--- a/src/authentication/EstonianIdLoginPage.test.tsx
+++ b/src/authentication/EstonianIdLoginPage.test.tsx
@@ -21,6 +21,7 @@ describe('Estonian ID login page', () => {
     useConfigMock.mockImplementation(() => ({
       authenticationMethod: AuthenticationMethod.ESTONIAN_ID,
       defaultLanguage: Language.ENGLISH,
+      addressRequired: false,
     }));
     renderWrapped(<LoginPage />);
     createIdAuthenticationSessionMock.mockResolvedValue({

--- a/src/authentication/EstonianIdLoginPage.test.tsx
+++ b/src/authentication/EstonianIdLoginPage.test.tsx
@@ -1,22 +1,28 @@
 import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 
-import { EstonianIdLoginPage } from './EstonianIdLoginPage';
-
-import { createIdAuthenticationSession } from '../api';
+import { LoginPage } from './LoginPage';
+import { createIdAuthenticationSession, AuthenticationMethod, Language } from '../api';
+import { useConfig } from '../common';
 import { renderWrapped } from '../testHelpers';
 
 jest.mock('../api');
+jest.mock('../common');
 const createIdAuthenticationSessionMock = createIdAuthenticationSession as jest.MockedFunction<
   typeof createIdAuthenticationSession
 >;
+const useConfigMock = useConfig as jest.MockedFunction<typeof useConfig>;
 
 describe('Estonian ID login page', () => {
   beforeEach(() => {
     // jsdom does not implement navigation, except for hash change, so we have to mock and edit window.location with this workaround
     delete window.location;
     window.location = ({ assign: jest.fn() } as any) as Location;
-    renderWrapped(<EstonianIdLoginPage />);
+    useConfigMock.mockImplementation(() => ({
+      authenticationMethod: AuthenticationMethod.ESTONIAN_ID,
+      defaultLanguage: Language.ENGLISH,
+    }));
+    renderWrapped(<LoginPage />);
     createIdAuthenticationSessionMock.mockResolvedValue({
       redirectUrl: 'https://example.com/redirect',
     });

--- a/src/authentication/LoginPage.tsx
+++ b/src/authentication/LoginPage.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
+import { Spinner } from 'theme-ui';
 
 import { useConfig } from '../common';
 import { MagicLinkLoginPage } from './MagicLinkLoginPage';
 import { EstonianIdLoginPage } from './EstonianIdLoginPage';
 import { AuthenticationMethod } from '../api';
-import { Spinner } from 'theme-ui';
 
 export const LoginPage = () => {
   const config = useConfig();

--- a/src/authentication/LoginPage.tsx
+++ b/src/authentication/LoginPage.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { useConfig } from '../common';
+import { MagicLinkLoginPage } from './MagicLinkLoginPage';
+import { EstonianIdLoginPage } from './EstonianIdLoginPage';
+import { AuthenticationMethod } from '../api';
+import { Spinner } from 'theme-ui';
+
+export const LoginPage = () => {
+  const config = useConfig();
+  if (!config) {
+    return <Spinner variant="spinner.main" />;
+  }
+  const LoginImplementation = loginImplementation[config.authenticationMethod];
+  return <LoginImplementation />;
+};
+
+const loginImplementation: Record<AuthenticationMethod, React.FC> = {
+  ESTONIAN_ID: EstonianIdLoginPage,
+  MAGIC_LINK: MagicLinkLoginPage,
+};

--- a/src/authentication/MagicLinkLoginPage.test.tsx
+++ b/src/authentication/MagicLinkLoginPage.test.tsx
@@ -1,17 +1,24 @@
 import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 
-import { MagicLinkLoginPage } from './MagicLinkLoginPage';
+import { LoginPage } from './LoginPage';
 
-import { createMagicLink } from '../api';
+import { createMagicLink, AuthenticationMethod, Language } from '../api';
+import { useConfig } from '../common';
 import { renderWrapped } from '../testHelpers';
 
 jest.mock('../api');
+jest.mock('../common');
 const createMagicLinkMock = createMagicLink as jest.MockedFunction<typeof createMagicLink>;
+const useConfigMock = useConfig as jest.MockedFunction<typeof useConfig>;
 
 describe('Magic link login page', () => {
   beforeEach(() => {
-    renderWrapped(<MagicLinkLoginPage />);
+    useConfigMock.mockImplementation(() => ({
+      authenticationMethod: AuthenticationMethod.MAGIC_LINK,
+      defaultLanguage: Language.ENGLISH,
+    }));
+    renderWrapped(<LoginPage />);
     createMagicLinkMock.mockImplementation(() =>
       Promise.resolve({
         creationTime: new Date().toISOString(),

--- a/src/authentication/MagicLinkLoginPage.test.tsx
+++ b/src/authentication/MagicLinkLoginPage.test.tsx
@@ -17,6 +17,7 @@ describe('Magic link login page', () => {
     useConfigMock.mockImplementation(() => ({
       authenticationMethod: AuthenticationMethod.MAGIC_LINK,
       defaultLanguage: Language.ENGLISH,
+      addressRequired: false,
     }));
     renderWrapped(<LoginPage />);
     createMagicLinkMock.mockImplementation(() =>

--- a/src/authentication/index.ts
+++ b/src/authentication/index.ts
@@ -1,5 +1,4 @@
-export * from './MagicLinkLoginPage';
 export * from './AuthenticationCallbackPage';
 export * from './context';
 export * from './AuthenticatedRoute';
-export * from './EstonianIdLoginPage';
+export * from './LoginPage';


### PR DESCRIPTION
Pick the login method on the login page based on the authentication method of the instance. I'm testing the login page by changing the tests of the individual implementations to go through the main login page, like users would use it.