### PR TITLE
Antibody test test

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -211,11 +211,11 @@ export interface TestResults {
   creationTime: string;
 }
 
-export type ResultInterpretationTheme = 'POSITIVE' | 'NEGATIVE' | 'NEUTRAL' | 'MUTED';
+export type InterpretationTheme = 'POSITIVE' | 'NEGATIVE' | 'NEUTRAL' | 'MUTED';
 
 export interface ResultInterpretation {
   name: string;
-  theme: ResultInterpretationTheme;
+  theme: InterpretationTheme;
 }
 
 export interface Test {
@@ -247,19 +247,30 @@ export async function fetchTests(
 export type FieldType = 'boolean' | 'string' | 'number' | 'integer' | 'null';
 
 export interface FieldSchema {
-  type: FieldType;
-  title: string;
+  type?: FieldType;
+  title?: string;
   description?: string;
   enum?: FieldValue[];
-  oneOf?: { title: string; const: FieldValue }[];
+  const?: FieldValue;
+  oneOf?: FieldSchema[];
 }
 
 export interface ObjectSchema {
   type: 'object';
+  $schema?: string;
   title?: string;
   description?: string;
   properties: { [key: string]: FieldSchema };
   required?: string[];
+}
+
+export interface InterpretationRule {
+  output: {
+    namePattern: string;
+    theme: InterpretationTheme;
+    propertyVariables?: Record<string, any>;
+  };
+  condition: ObjectSchema;
 }
 
 export interface TestType {
@@ -267,7 +278,7 @@ export interface TestType {
   name: string;
   resultsSchema: ObjectSchema;
   neededPermissionToAddResults: string;
-  interpretationRules?: ResultInterpretation[];
+  interpretationRules?: InterpretationRule[];
 }
 
 export async function fetchTestTypes(options: AuthenticatedHttpOptions): Promise<TestType[]> {

--- a/src/testHelpers.tsx
+++ b/src/testHelpers.tsx
@@ -46,3 +46,133 @@ export function aTestType(): TestType {
     neededPermissionToAddResults: 'CREATE_TESTS_WITHOUT_ACCESS_PASS',
   };
 }
+
+export function antibodyTestType(): TestType {
+  return {
+    id: 'some-antibody-test-type',
+    name: 'Antibody test',
+    resultsSchema: {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      title: 'COVID-19 Take Home Test',
+      type: 'object',
+      properties: {
+        c: {
+          title: 'Control',
+          type: 'boolean',
+          description: "Indicator if sample doesn't show COVID-19",
+        },
+        igg: {
+          title: 'IgG',
+          type: 'boolean',
+          description: 'Indicator if sample shows IgG positive',
+        },
+        igm: {
+          title: 'IgM',
+          type: 'boolean',
+          description: 'Indicator if sample shows IgM positive',
+        },
+      },
+    },
+    neededPermissionToAddResults: 'CREATE_TESTS_WITHOUT_ACCESS_PASS',
+    interpretationRules: [
+      {
+        output: {
+          namePattern: 'IgG antibodies found',
+          theme: 'POSITIVE',
+          propertyVariables: {},
+        },
+        condition: {
+          type: 'object',
+          properties: {
+            c: {
+              type: 'boolean',
+              const: true,
+            },
+            igg: {
+              type: 'boolean',
+              const: true,
+            },
+          },
+          required: ['c', 'igg'],
+        },
+      },
+      {
+        output: {
+          namePattern: 'IgG antibodies not found',
+          theme: 'MUTED',
+          propertyVariables: {},
+        },
+        condition: {
+          type: 'object',
+          properties: {
+            c: {
+              type: 'boolean',
+              const: true,
+            },
+            igg: {
+              type: 'boolean',
+              const: false,
+            },
+          },
+          required: ['c', 'igg'],
+        },
+      },
+      {
+        output: {
+          namePattern: 'IgM antibodies found',
+          theme: 'NEUTRAL',
+        },
+        condition: {
+          type: 'object',
+          properties: {
+            c: {
+              type: 'boolean',
+              const: true,
+            },
+            igm: {
+              type: 'boolean',
+              const: true,
+            },
+          },
+          required: ['c', 'igm'],
+        },
+      },
+      {
+        output: {
+          namePattern: 'IgM antibodies not found',
+          theme: 'MUTED',
+        },
+        condition: {
+          type: 'object',
+          properties: {
+            c: {
+              type: 'boolean',
+              const: true,
+            },
+            igm: {
+              type: 'boolean',
+              const: false,
+            },
+          },
+          required: ['c', 'igm'],
+        },
+      },
+      {
+        output: {
+          namePattern: 'Test Invalid',
+          theme: 'MUTED',
+        },
+        condition: {
+          type: 'object',
+          properties: {
+            c: {
+              type: 'boolean',
+              const: false,
+            },
+          },
+          required: ['c'],
+        },
+      },
+    ],
+  };
+}

--- a/src/testing/AddTestToIdentifierPage.test.tsx
+++ b/src/testing/AddTestToIdentifierPage.test.tsx
@@ -16,16 +16,19 @@ describe(AddTestToIdentifierPage, () => {
   beforeEach(() => {
     mockConfigForEstonianIdMethodAndEnglish();
     mockAuthentication();
-    mockHttp().get('/api/v1/test-types').reply(200, [aTestType()]);
-
-    renderWrapped(<AddTestToIdentifierPage />);
   });
 
   it('focuses identifier input', async () => {
+    mockHttp().get('/api/v1/test-types').reply(200, [aTestType()]);
+    renderWrapped(<AddTestToIdentifierPage />);
+
     expect(identifierInput()).toHaveFocus();
   });
 
   it('only allows submitting the form once the identifier is valid and required test fields are filled, showing validation errors', async () => {
+    mockHttp().get('/api/v1/test-types').reply(200, [aTestType()]);
+    renderWrapped(<AddTestToIdentifierPage />);
+
     const positiveOption = await screen.findByRole('radio', { name: 'Positive' });
 
     userEvent.type(identifierInput(), '79210030814'); // invalid id code
@@ -42,7 +45,10 @@ describe(AddTestToIdentifierPage, () => {
     await waitFor(() => expect(submitButton()).not.toBeDisabled());
   });
 
-  it('creates a user for the authentication method from config and the filled identifier and adds a test for that user', async () => {
+  it('creates a user and and adds a PCR test for that user', async () => {
+    mockHttp().get('/api/v1/test-types').reply(200, [aTestType()]);
+    renderWrapped(<AddTestToIdentifierPage />);
+
     const negativeOption = await screen.findByRole('radio', { name: 'Negative' });
     const positiveOption = screen.getByRole('radio', { name: 'Positive' });
 
@@ -78,6 +84,9 @@ describe(AddTestToIdentifierPage, () => {
   });
 
   it('shows error when user cannot be created', async () => {
+    mockHttp().get('/api/v1/test-types').reply(200, [aTestType()]);
+    renderWrapped(<AddTestToIdentifierPage />);
+
     userEvent.type(identifierInput(), '39210030814');
 
     mockHttp()
@@ -91,6 +100,9 @@ describe(AddTestToIdentifierPage, () => {
   });
 
   it('shows error when test cannot be created', async () => {
+    mockHttp().get('/api/v1/test-types').reply(200, [aTestType()]);
+    renderWrapped(<AddTestToIdentifierPage />);
+
     const negativeOption = await screen.findByRole('radio', { name: 'Negative' });
 
     userEvent.type(identifierInput(), '39210030814');

--- a/src/testing/InterpretationBadge.tsx
+++ b/src/testing/InterpretationBadge.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Badge, BadgeProps } from 'theme-ui';
 
-import { ResultInterpretation, ResultInterpretationTheme } from '../api';
+import { ResultInterpretation, InterpretationTheme } from '../api';
 
 const AnyBadge = Badge as any;
 
@@ -18,7 +18,7 @@ export const InterpretationBadge = ({
   );
 };
 
-function variantForInterpretationTheme(theme: ResultInterpretationTheme) {
+function variantForInterpretationTheme(theme: InterpretationTheme) {
   switch (theme) {
     case 'MUTED':
       return 'muted';


### PR DESCRIPTION
## Context

Instead of PCR tests, the first use of the app will be antibody tests. To have more confidence that the different mechanism (checkboxes instead of radios etc.) work, a test should be added.

## Changes

A test is added for the _add test to identifier page_ for an antibody-type test. In addition, an interpretation rule type has been added (previously incorrectly typed as result interpretation).