### PR TITLE
Date formatting depending on language

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,1 +1,2 @@
 export * from './useConfig';
+export * from './useI18n';

--- a/src/common/useI18n.ts
+++ b/src/common/useI18n.ts
@@ -1,0 +1,5 @@
+import { formatDate } from '../i18n/date';
+
+export function useI18n(): { formatDate: (date: Date) => string } {
+  return { formatDate };
+}

--- a/src/common/useI18n.ts
+++ b/src/common/useI18n.ts
@@ -1,5 +1,10 @@
+import { useConfig } from './useConfig';
 import { formatDate } from '../i18n/date';
 
 export function useI18n(): { formatDate: (date: Date) => string } {
-  return { formatDate };
+  const { defaultLanguage } = useConfig();
+
+  return {
+    formatDate: (date) => formatDate(date, defaultLanguage),
+  };
 }

--- a/src/i18n/date.ts
+++ b/src/i18n/date.ts
@@ -1,5 +1,17 @@
 import { format } from 'date-fns';
+import { enGB, et } from 'date-fns/locale';
 
-export function formatDate(date: Date): string {
-  return format(date, 'd MMM yyyy');
+import { Language } from '../api';
+
+export function formatDate(date: Date, language: Language): string {
+  const localeForLanguage: Record<Language, Locale> = {
+    [Language.ENGLISH]: enGB,
+    [Language.ESTONIAN]: et,
+  };
+  const formatForLanguage: Record<Language, string> = {
+    [Language.ENGLISH]: 'd MMM yyyy',
+    [Language.ESTONIAN]: 'd. MMMM yyyy',
+  };
+
+  return format(date, formatForLanguage[language], { locale: localeForLanguage[language] });
 }

--- a/src/i18n/date.ts
+++ b/src/i18n/date.ts
@@ -1,0 +1,5 @@
+import { format } from 'date-fns';
+
+export function formatDate(date: Date): string {
+  return format(date, 'd MMM yyyy');
+}

--- a/src/identity/IdentityPage.test.tsx
+++ b/src/identity/IdentityPage.test.tsx
@@ -28,7 +28,10 @@ jest.mock('qrcode.react', () => ({ value }: { value: string }) => `Mock QRCode: 
 
 jest.mock('../api');
 jest.mock('../authentication');
-jest.mock('../common');
+jest.mock('../common', () => ({
+  ...jest.requireActual('../common'),
+  useConfig: jest.fn(),
+}));
 
 const fetchUserMock = fetchUser as jest.MockedFunction<typeof fetchUser>;
 const updateUserMock = updateUser as jest.MockedFunction<typeof updateUser>;
@@ -642,5 +645,5 @@ function secondsFromNow(seconds: number): Date {
 }
 
 function nextTick() {
-  return new Promise(resolve => setImmediate(resolve));
+  return new Promise((resolve) => setImmediate(resolve));
 }

--- a/src/identity/IdentityPage.tsx
+++ b/src/identity/IdentityPage.tsx
@@ -17,11 +17,11 @@ import {
   NavLinkProps as RouterNavLinkProps,
   Redirect,
 } from 'react-router-dom';
-import { format } from 'date-fns';
 import { Message } from 'retranslate';
 
 import { useUser } from '../resources';
 import { Profile, Address } from '../api';
+import { formatDate } from '../i18n/date';
 
 import { ProfileForm } from './ProfileForm';
 import { AddressForm } from './AddressForm';
@@ -97,7 +97,7 @@ export const IdentityPage = () => {
         <Text mb={5}>
           {/* TODO: Add Estonian date formatting */}
           <Message>identityPage.dateOfBirth</Message>:{' '}
-          {format(new Date(user.profile.dateOfBirth), 'd MMM yyyy')}
+          {formatDate(new Date(user.profile.dateOfBirth))}
         </Text>
         {isOwnUser ? (
           <Flex as="nav">

--- a/src/identity/IdentityPage.tsx
+++ b/src/identity/IdentityPage.tsx
@@ -21,7 +21,6 @@ import { Message } from 'retranslate';
 
 import { useUser } from '../resources';
 import { Profile, Address } from '../api';
-import { formatDate } from '../i18n/date';
 
 import { ProfileForm } from './ProfileForm';
 import { AddressForm } from './AddressForm';
@@ -32,6 +31,7 @@ import { useAuthentication } from '../authentication';
 import { TestList } from '../testing';
 import { ViewingOtherProfileHeader } from './ViewingOtherProfileHeader';
 import { useConfig } from '../common';
+import { useI18n } from '../common';
 
 const Small = ({ children }: { children: React.ReactNode }) => (
   <Text as="small" sx={{ fontSize: 2, fontWeight: 2 }}>
@@ -49,6 +49,7 @@ export const IdentityPage = () => {
   const { user, update: updateUser } = useUser(userId);
   const { userId: authenticatedUserId } = useAuthentication();
   const { addressRequired } = useConfig() || { addressRequired: false };
+  const { formatDate } = useI18n();
   const isOwnUser = userId === authenticatedUserId;
 
   if (!user) {

--- a/src/testing/ConfirmIdentity.tsx
+++ b/src/testing/ConfirmIdentity.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Box, Spinner, Alert, Text, Button, Heading } from 'theme-ui';
 import { Message } from 'retranslate';
 
-import { formatDate } from '../i18n/date';
+import { useI18n } from '../common';
 import { useUser, useCountries } from '../resources';
 import { Warning as WarningIcon } from '../icons';
 
@@ -17,6 +17,7 @@ export const ConfirmIdentity = ({
 }) => {
   const { countries } = useCountries();
   const { user } = useUser(userId);
+  const { formatDate } = useI18n();
 
   if (!user || !countries.length) {
     return <Spinner mx="auto" mt={4} sx={{ display: 'block' }} />;

--- a/src/testing/ConfirmIdentity.tsx
+++ b/src/testing/ConfirmIdentity.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { format } from 'date-fns';
 import { Box, Spinner, Alert, Text, Button, Heading } from 'theme-ui';
 import { Message } from 'retranslate';
 
+import { formatDate } from '../i18n/date';
 import { useUser, useCountries } from '../resources';
 import { Warning as WarningIcon } from '../icons';
 
@@ -44,8 +44,7 @@ export const ConfirmIdentity = ({
         {firstName} {lastName}
       </Heading>
       <Text mb={4}>
-        <Message>confirmIdentity.dateOfBirth</Message>:{' '}
-        {format(new Date(dateOfBirth), 'd MMM yyyy')}
+        <Message>confirmIdentity.dateOfBirth</Message>: {formatDate(new Date(dateOfBirth))}
         {/* TODO: Add Estonian date formatting  */}
       </Text>
       {text(address1)}

--- a/src/testing/TestDetailPage.tsx
+++ b/src/testing/TestDetailPage.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import { Container, Heading, Spinner, Text, Divider, Flex, Box } from 'theme-ui';
-import { format } from 'date-fns';
 import { useTranslations, Message } from 'retranslate';
 
+import { formatDate } from '../i18n/date';
 import { useTest, useTestTypes } from '../resources';
 import { InterpretationBadge } from './InterpretationBadge';
 
@@ -38,7 +38,7 @@ export const TestDetailPage = () => {
       </Heading>
       <Text mb={2}>
         {/* TODO: Add Estonian date formatting */}
-        <Message>testDetailPage.date</Message>: {format(new Date(test!.creationTime), 'd MMM yyyy')}
+        <Message>testDetailPage.date</Message>: {formatDate(new Date(test!.creationTime))}
       </Text>
       {test.resultsInterpretations?.map((interpretation, index) => (
         <InterpretationBadge key={index} interpretation={interpretation} mr={2} />

--- a/src/testing/TestDetailPage.tsx
+++ b/src/testing/TestDetailPage.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom';
 import { Container, Heading, Spinner, Text, Divider, Flex, Box } from 'theme-ui';
 import { useTranslations, Message } from 'retranslate';
 
-import { formatDate } from '../i18n/date';
+import { useI18n } from '../common';
 import { useTest, useTestTypes } from '../resources';
 import { InterpretationBadge } from './InterpretationBadge';
 
@@ -12,6 +12,8 @@ export const TestDetailPage = () => {
   const { translate } = useTranslations();
   const { testTypes } = useTestTypes();
   const { test, loading } = useTest(testId);
+  const { formatDate } = useI18n();
+
   if (loading || !test) {
     return <Spinner variant="spinner.main" />;
   }

--- a/src/testing/TestList.tsx
+++ b/src/testing/TestList.tsx
@@ -3,7 +3,7 @@ import { Flex, Box, Spinner, Text, Button, ButtonProps, Heading, FlexProps } fro
 import { LinkProps, Link } from 'react-router-dom';
 import { Message } from 'retranslate';
 
-import { formatDate } from '../i18n/date';
+import { useI18n } from '../common';
 import { Plus as PlusIcon, Caret } from '../icons';
 import { useTests, useTestTypes } from '../resources';
 
@@ -15,6 +15,7 @@ const LinkFlex = Flex as React.FC<FlexProps & LinkProps>;
 export const TestList = ({ userId }: { userId: string }) => {
   const { loading: loadingTests, tests } = useTests(userId);
   const { permittedTestTypes, loading: loadingTestTypes } = useTestTypes();
+  const { formatDate } = useI18n();
 
   if (loadingTests || loadingTestTypes) {
     return <Spinner mx="auto" mt={6} sx={{ display: 'block' }} />;

--- a/src/testing/TestList.tsx
+++ b/src/testing/TestList.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Flex, Box, Spinner, Text, Button, ButtonProps, Heading, FlexProps } from 'theme-ui';
 import { LinkProps, Link } from 'react-router-dom';
-import { format } from 'date-fns';
 import { Message } from 'retranslate';
 
+import { formatDate } from '../i18n/date';
 import { Plus as PlusIcon, Caret } from '../icons';
 import { useTests, useTestTypes } from '../resources';
 
@@ -45,7 +45,7 @@ export const TestList = ({ userId }: { userId: string }) => {
                   <Box>
                     <Heading as="h3" mb={2}>
                       {/* TODO: Add Estonian date formatting */}
-                      {format(new Date(test.creationTime), 'd MMM yyyy')}
+                      {formatDate(new Date(test.creationTime))}
                     </Heading>
                     {test.resultsInterpretations?.map((interpretation, index) => (
                       <InterpretationBadge key={index} interpretation={interpretation} mr={2} />


### PR DESCRIPTION
Closes https://github.com/cov-clear/web/issues/49.

## Context

🇪🇪 When the app is used in Estonian, it should also show dates in Estonian.

## Changes

Dates are formatted depending on the language from the config, using a hook.

## Screenshots

<img src="https://user-images.githubusercontent.com/5443561/81401796-bb03b580-9138-11ea-8862-a12bb222d1cd.png" width="375" />
