### PR TITLE
Shorten copy on scan user code button

### DIFF
--- a/src/i18n/et.json
+++ b/src/i18n/et.json
@@ -54,7 +54,7 @@
   "profileForm.sex.option.male": "Mees",
   "profileForm.button": "Edasi",
   "sharingCode.description": "Luba teisel kasutajal oma kood skaneerida, et turvaliselt oma tulemusi jagada",
-  "sharingCode.button": "Skaneeri teise kasutaja kood",
+  "sharingCode.button": "Skaneeri kood",
   "viewingOtherProfileHeader.heading": "Patsiendi profiil",
   "viewingOtherProfileHeader.button": "Sulge",
   "scanPage.error.incorrectCode": "Vigane kood",


### PR DESCRIPTION
## Context

The copy was previously too long in Estonian:
<img src="https://user-images.githubusercontent.com/5443561/81401984-2c436880-9139-11ea-8ff6-8a333b75b523.png" width="375" />