### PR TITLE
Navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,9 @@ const App = () => {
   return (
     <Switch>
       <AuthenticatedRoute path="/scan" exact>
-        <ScanPage />
+        <Container sx={{ maxWidth: '600px' }}>
+          <ScanPage />
+        </Container>
       </AuthenticatedRoute>
 
       <Container variant="page">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Switch, Route, Redirect } from 'react-router-dom';
 import { ThemeProvider, Spinner, Container } from 'theme-ui';
 import { Provider as TranslationProvider } from 'retranslate';
 
+import { Navigation } from './Navigation';
 import {
   LoginPage,
   AuthenticationCallbackPage,
@@ -10,7 +11,6 @@ import {
   AuthenticatedRoute,
   useAuthentication,
 } from './authentication';
-
 import { messages } from './i18n/messages';
 import theme from './theme';
 import { NotFoundPage } from './staticPages';
@@ -20,6 +20,13 @@ import { AddTestPage, TestDetailPage, AddTestToIdentifierPage } from './testing'
 import { BulkUserCreationPage } from './admin';
 import { useConfig } from './common';
 import { Language } from './api';
+import {
+  PERMISSIONS_REQUIRED_FOR_ADD_TEST_TO_IDENTIFIER_PAGE,
+  PERMISSIONS_REQUIRED_FOR_USER_CREATION_PAGE,
+  ADD_TEST_TO_IDENTIFIER_PATH,
+  USER_CREATION_PATH,
+  HOME_PATH,
+} from './paths';
 
 // Includes fairly large dependencies for QR scanning and workers
 const ScanPage = lazy(async () => {
@@ -29,69 +36,73 @@ const ScanPage = lazy(async () => {
 
 const App = () => {
   const { userId } = useAuthentication();
+  const isLoggedIn = !!userId;
 
   return (
     <Switch>
       <AuthenticatedRoute path="/scan" exact>
-        <Container sx={{ maxWidth: '600px' }}>
+        <Container sx={{ maxWidth: 'pageWidth' }}>
           <ScanPage />
         </Container>
       </AuthenticatedRoute>
 
-      <Container variant="page">
-        <Switch>
-          <Route
-            path="/"
-            exact
-            render={() => {
-              if (userId) {
-                return <Redirect to={`/users/${userId}`} />;
-              }
-              return <Redirect to="/login" />;
-            }}
-          />
+      <>
+        {isLoggedIn && <Navigation />}
 
-          <Route path="/login" exact>
-            <LoginPage />
-          </Route>
+        <Container variant="page">
+          <Switch>
+            <Route
+              path="/"
+              exact
+              render={() => <Redirect to={isLoggedIn ? HOME_PATH : '/login'} />}
+            />
 
-          <Route path="/authentication-callback" exact>
-            <AuthenticationCallbackPage />
-          </Route>
+            <Route path="/login" exact>
+              <LoginPage />
+            </Route>
 
-          <AuthenticatedRoute path="/users/:userId/add-test">
-            <AddTestPage />
-          </AuthenticatedRoute>
+            <Route path="/authentication-callback" exact>
+              <AuthenticationCallbackPage />
+            </Route>
 
-          <AuthenticatedRoute path="/users/:userId">
-            <IdentityPage />
-          </AuthenticatedRoute>
+            <AuthenticatedRoute path={HOME_PATH}>
+              <IdentityPage />
+            </AuthenticatedRoute>
 
-          <AuthenticatedRoute path="/tests/:testId" exact>
-            <TestDetailPage />
-          </AuthenticatedRoute>
+            <AuthenticatedRoute path="/users/:userId/add-test">
+              <AddTestPage />
+            </AuthenticatedRoute>
 
-          <AuthenticatedRoute
-            path="/add-test"
-            exact
-            requiredPermissions={['CREATE_USERS', 'CREATE_TESTS_WITHOUT_ACCESS_PASS']}
-          >
-            <AddTestToIdentifierPage />
-          </AuthenticatedRoute>
+            <AuthenticatedRoute path="/users/:userId">
+              <IdentityPage />
+            </AuthenticatedRoute>
 
-          <AuthenticatedRoute
-            path="/admin/create-users"
-            exact
-            requiredPermissions={['BULK_CREATE_USERS']}
-          >
-            <BulkUserCreationPage />
-          </AuthenticatedRoute>
+            <AuthenticatedRoute path="/tests/:testId" exact>
+              <TestDetailPage />
+            </AuthenticatedRoute>
 
-          <Route path="*">
-            <NotFoundPage />
-          </Route>
-        </Switch>
-      </Container>
+            <AuthenticatedRoute
+              path={ADD_TEST_TO_IDENTIFIER_PATH}
+              exact
+              requiredPermissions={PERMISSIONS_REQUIRED_FOR_ADD_TEST_TO_IDENTIFIER_PAGE}
+            >
+              <AddTestToIdentifierPage />
+            </AuthenticatedRoute>
+
+            <AuthenticatedRoute
+              path={USER_CREATION_PATH}
+              exact
+              requiredPermissions={PERMISSIONS_REQUIRED_FOR_USER_CREATION_PAGE}
+            >
+              <BulkUserCreationPage />
+            </AuthenticatedRoute>
+
+            <Route path="*">
+              <NotFoundPage />
+            </Route>
+          </Switch>
+        </Container>
+      </>
     </Switch>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense, lazy } from 'react';
 import { BrowserRouter, Switch, Route, Redirect } from 'react-router-dom';
-import { ThemeProvider, Spinner } from 'theme-ui';
+import { ThemeProvider, Spinner, Container } from 'theme-ui';
 import { Provider as TranslationProvider } from 'retranslate';
 
 import {
@@ -32,51 +32,64 @@ const App = () => {
 
   return (
     <Switch>
-      <Route
-        path="/"
-        exact
-        render={() => {
-          if (userId) {
-            return <Redirect to={`/users/${userId}`} />;
-          }
-          return <Redirect to="/login" />;
-        }}
-      />
-      <Route path="/login" exact>
-        <LoginPage />
-      </Route>
-      <Route path="/authentication-callback" exact>
-        <AuthenticationCallbackPage />
-      </Route>
-      <AuthenticatedRoute path="/users/:userId/add-test">
-        <AddTestPage />
-      </AuthenticatedRoute>
-      <AuthenticatedRoute path="/users/:userId">
-        <IdentityPage />
-      </AuthenticatedRoute>
-      <AuthenticatedRoute path="/tests/:testId" exact>
-        <TestDetailPage />
-      </AuthenticatedRoute>
       <AuthenticatedRoute path="/scan" exact>
         <ScanPage />
       </AuthenticatedRoute>
-      <AuthenticatedRoute
-        path="/add-test"
-        exact
-        requiredPermissions={['CREATE_USERS', 'CREATE_TESTS_WITHOUT_ACCESS_PASS']}
-      >
-        <AddTestToIdentifierPage />
-      </AuthenticatedRoute>
-      <AuthenticatedRoute
-        path="/admin/create-users"
-        exact
-        requiredPermissions={['BULK_CREATE_USERS']}
-      >
-        <BulkUserCreationPage />
-      </AuthenticatedRoute>
-      <Route path="*">
-        <NotFoundPage />
-      </Route>
+
+      <Container variant="page">
+        <Switch>
+          <Route
+            path="/"
+            exact
+            render={() => {
+              if (userId) {
+                return <Redirect to={`/users/${userId}`} />;
+              }
+              return <Redirect to="/login" />;
+            }}
+          />
+
+          <Route path="/login" exact>
+            <LoginPage />
+          </Route>
+
+          <Route path="/authentication-callback" exact>
+            <AuthenticationCallbackPage />
+          </Route>
+
+          <AuthenticatedRoute path="/users/:userId/add-test">
+            <AddTestPage />
+          </AuthenticatedRoute>
+
+          <AuthenticatedRoute path="/users/:userId">
+            <IdentityPage />
+          </AuthenticatedRoute>
+
+          <AuthenticatedRoute path="/tests/:testId" exact>
+            <TestDetailPage />
+          </AuthenticatedRoute>
+
+          <AuthenticatedRoute
+            path="/add-test"
+            exact
+            requiredPermissions={['CREATE_USERS', 'CREATE_TESTS_WITHOUT_ACCESS_PASS']}
+          >
+            <AddTestToIdentifierPage />
+          </AuthenticatedRoute>
+
+          <AuthenticatedRoute
+            path="/admin/create-users"
+            exact
+            requiredPermissions={['BULK_CREATE_USERS']}
+          >
+            <BulkUserCreationPage />
+          </AuthenticatedRoute>
+
+          <Route path="*">
+            <NotFoundPage />
+          </Route>
+        </Switch>
+      </Container>
     </Switch>
   );
 };

--- a/src/Navigation/Navigation.test.tsx
+++ b/src/Navigation/Navigation.test.tsx
@@ -1,0 +1,76 @@
+import React, { ReactNode } from 'react';
+import { Router, Route, Switch } from 'react-router-dom';
+import { createMemoryHistory, MemoryHistory } from 'history';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import decodeToken from 'jwt-decode';
+
+import { renderWrapped } from '../testHelpers';
+import { Navigation } from '.';
+import { Provider as AuthenticationProvider, AuthenticatedRoute } from '../authentication';
+import { PERMISSIONS_REQUIRED_FOR_ADD_TEST_TO_IDENTIFIER_PAGE } from '../paths';
+
+jest.mock('jwt-decode');
+
+describe(Navigation, () => {
+  afterEach(() => {
+    window.localStorage.removeItem('token');
+  });
+
+  it('logs out and deletes token from local storage log out is clicked', async () => {
+    window.localStorage.setItem('token', 'some-token');
+    (decodeToken as jest.Mock).mockImplementation((token) =>
+      token === 'some-token' ? { userId: 'some-user-id', roles: [], permissions: [] } : {}
+    );
+
+    const history = createMemoryHistory();
+    renderWithRouterAndAuthentication(
+      <>
+        <Navigation />
+        <Switch>
+          <Route path="/login">Login</Route>
+          <AuthenticatedRoute path="/some-path">Some page</AuthenticatedRoute>
+        </Switch>
+      </>,
+      history
+    );
+
+    history.push('/some-path');
+    expect(screen.getByText('Some page')).toBeInTheDocument();
+
+    const logoutButton = screen.getByRole('link', { name: 'Log out' });
+    userEvent.click(logoutButton);
+
+    expect(screen.getByText('Login')).toBeInTheDocument();
+    expect(window.localStorage.getItem('token')).toBeNull();
+  });
+
+  it('only shows navigation links for the pages user has permissions for', async () => {
+    window.localStorage.setItem('token', 'some-token');
+    (decodeToken as jest.Mock).mockImplementation((token) =>
+      token === 'some-token'
+        ? {
+            userId: 'some-user-id',
+            roles: [],
+            permissions: PERMISSIONS_REQUIRED_FOR_ADD_TEST_TO_IDENTIFIER_PAGE,
+          }
+        : {}
+    );
+
+    renderWithRouterAndAuthentication(<Navigation />);
+
+    expect(screen.getByRole('link', { name: 'Add test' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Create users' })).not.toBeInTheDocument();
+  });
+
+  function renderWithRouterAndAuthentication(
+    element: ReactNode,
+    history: MemoryHistory = createMemoryHistory()
+  ) {
+    renderWrapped(
+      <AuthenticationProvider>
+        <Router history={history}>{element}</Router>
+      </AuthenticationProvider>
+    );
+  }
+});

--- a/src/Navigation/Navigation.tsx
+++ b/src/Navigation/Navigation.tsx
@@ -1,0 +1,61 @@
+import React, { FC } from 'react';
+import { NavLink as RouterNavLink, NavLinkProps as RouterNavLinkProps } from 'react-router-dom';
+import {
+  Flex,
+  NavLink as ThemeUiNavLink,
+  NavLinkProps as ThemeUiNavLinkProps,
+  Box,
+} from 'theme-ui';
+import { Message } from 'retranslate';
+
+import {
+  PERMISSIONS_REQUIRED_FOR_ADD_TEST_TO_IDENTIFIER_PAGE,
+  PERMISSIONS_REQUIRED_FOR_USER_CREATION_PAGE,
+  ADD_TEST_TO_IDENTIFIER_PATH,
+  USER_CREATION_PATH,
+  HOME_PATH,
+} from '../paths';
+import { useAuthentication } from '../authentication';
+
+const CombinedNavLink = ThemeUiNavLink as FC<ThemeUiNavLinkProps & RouterNavLinkProps>;
+
+const NavLink: FC<RouterNavLinkProps> = ({ to, children }) => {
+  return (
+    <CombinedNavLink p={2} as={RouterNavLink} to={to}>
+      {children}
+    </CombinedNavLink>
+  );
+};
+
+export const Navigation = () => {
+  const { hasPermission: userHasPermission, signOut } = useAuthentication();
+  const hasPermissions = (permissions: string[]) => permissions.every(userHasPermission);
+
+  return (
+    <Flex as="nav" p={2} sx={{ maxWidth: 'pageWidth', justifyContent: 'space-between' }} mx="auto">
+      <Box>
+        {
+          <NavLink to={HOME_PATH}>
+            <Message>navigation.home</Message>
+          </NavLink>
+        }
+
+        {hasPermissions(PERMISSIONS_REQUIRED_FOR_USER_CREATION_PAGE) && (
+          <NavLink to={USER_CREATION_PATH}>
+            <Message>navigation.userCreation</Message>
+          </NavLink>
+        )}
+
+        {hasPermissions(PERMISSIONS_REQUIRED_FOR_ADD_TEST_TO_IDENTIFIER_PAGE) && (
+          <NavLink to={ADD_TEST_TO_IDENTIFIER_PATH}>
+            <Message>navigation.addTest</Message>
+          </NavLink>
+        )}
+      </Box>
+
+      <ThemeUiNavLink p={2} onClick={signOut} href="/">
+        Log out
+      </ThemeUiNavLink>
+    </Flex>
+  );
+};

--- a/src/Navigation/index.ts
+++ b/src/Navigation/index.ts
@@ -1,0 +1,1 @@
+export * from './Navigation';

--- a/src/admin/BulkUserCreationPage.tsx
+++ b/src/admin/BulkUserCreationPage.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import { Message, useTranslations } from 'retranslate';
-import { Box, Label, Heading, Container, Button, Text, Textarea, Alert, Select } from 'theme-ui';
+import { Box, Label, Heading, Button, Text, Textarea, Alert, Select } from 'theme-ui';
 import { useFormik } from 'formik';
 import * as yup from 'yup';
 
@@ -50,7 +50,7 @@ const BulkUserCreationPage: FC = () => {
   });
 
   return (
-    <Container variant="page">
+    <>
       <Heading as="h1" mb={4}>
         <Message>bulkUserCreationPage.heading</Message>
       </Heading>
@@ -110,7 +110,7 @@ const BulkUserCreationPage: FC = () => {
           {errorCreatingUsers.message}
         </Alert>
       )}
-    </Container>
+    </>
   );
 };
 

--- a/src/authentication/AuthenticationCallbackPage.test.tsx
+++ b/src/authentication/AuthenticationCallbackPage.test.tsx
@@ -75,9 +75,7 @@ describe('Link page', () => {
 
     it('replaces the route with the user page, removing it from history', async () => {
       history.push(`/authentication-callback?method=MAGIC_LINK&authCode=${authCode}`);
-      await waitFor(() =>
-        expect(history.location.pathname).toBe('/users/f99c9790-f137-404f-9bf1-243d6e3e6f3e')
-      );
+      await waitFor(() => expect(history.location.pathname).toBe('/profile'));
       history.goBack();
       expect(history.location.pathname).toBe('/');
     });

--- a/src/authentication/AuthenticationCallbackPage.tsx
+++ b/src/authentication/AuthenticationCallbackPage.tsx
@@ -4,7 +4,7 @@ import http from 'axios';
 import { useHistory, useLocation } from 'react-router-dom';
 import { authenticate, AuthenticationMethod } from '../api';
 import { useAuthentication } from './context';
-import { decode } from './token';
+import { HOME_PATH } from '../paths';
 
 export const AuthenticationCallbackPage = () => {
   const queryParams = useQuery();
@@ -23,15 +23,14 @@ export const AuthenticationCallbackPage = () => {
             cancelToken: cancelToken.token,
           });
           saveToken(token);
-          const { userId } = decode(token);
-          history.replace(`/users/${userId}`);
+          history.replace(HOME_PATH);
         } catch (error) {
           if (!http.isCancel(error)) {
-            history.replace(`/login?invalid=true`);
+            history.replace('/login?invalid=true');
           }
         }
       } else {
-        history.replace(`/login?invalid=true`);
+        history.replace('/login?invalid=true');
       }
     }
 

--- a/src/authentication/EstonianIdLoginPage.tsx
+++ b/src/authentication/EstonianIdLoginPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Message } from 'retranslate';
-import { Container, Heading, Button, Text, Alert, Link } from 'theme-ui';
+import { Heading, Button, Text, Alert, Link } from 'theme-ui';
 import { useState } from 'react';
 import { createIdAuthenticationSession } from '../api';
 import { useLocation } from 'react-router-dom';
@@ -18,7 +18,7 @@ export const EstonianIdLoginPage = () => {
   const invalidLink = urlParams.get('invalid');
 
   return (
-    <Container variant="page">
+    <>
       {invalidLink && (
         <Alert variant="secondary" mb={4}>
           <Message>error.authentication</Message>
@@ -43,6 +43,6 @@ export const EstonianIdLoginPage = () => {
       <Button variant="block" onClick={handleLogin} disabled={loading} mb={2}>
         <Message>loginPage.estonian.button</Message>
       </Button>
-    </Container>
+    </>
   );
 };

--- a/src/authentication/MagicLinkLoginPage.tsx
+++ b/src/authentication/MagicLinkLoginPage.tsx
@@ -1,17 +1,7 @@
 import React, { useState } from 'react';
 import { useFormik } from 'formik';
 import * as yup from 'yup';
-import {
-  Container,
-  Label,
-  Input,
-  Button,
-  Text,
-  Heading,
-  Box,
-  Alert,
-  Link as ThemeUiLink,
-} from 'theme-ui';
+import { Label, Input, Button, Text, Heading, Box, Alert, Link as ThemeUiLink } from 'theme-ui';
 
 import { createMagicLink } from '../api';
 import { Message, useTranslations } from 'retranslate';
@@ -30,7 +20,7 @@ export const MagicLinkLoginPage = () => {
   const invalidLink = urlParams.get('invalid');
 
   return (
-    <Container variant="page">
+    <>
       {invalidLink && !submitted && (
         <Alert variant="secondary" mb={4}>
           <Message>loginPage.invalidLink</Message>
@@ -61,7 +51,7 @@ export const MagicLinkLoginPage = () => {
       >
         <Message>loginPage.privacy</Message>
       </ThemeUiLink>
-    </Container>
+    </>
   );
 };
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,4 +1,8 @@
 {
+  "navigation.home": "Home",
+  "navigation.userCreation": "Create users",
+  "navigation.addTest": "Add test",
+  "navigation.logOut": "Log out",
   "notFoundPage.heading": "This page doesn't exist",
   "notFoundPage.imageAltText": "A woman flying away with a bundle of balloons",
   "notFoundPage.button": "Go to the start page",
@@ -57,8 +61,7 @@
   "profileForm.button": "Next",
   "sharingCode.description": "Let another user scan your code to securely share your results",
   "sharingCode.button": "Scan another user",
-  "viewingOtherProfileHeader.heading": "Patient profile",
-  "viewingOtherProfileHeader.button": "Close",
+  "viewingOtherProfileHeader.alert": "You are viewing another user's profile. Click \"Home\" to go back.",
   "scanPage.error.incorrectCode": "Incorrect code",
   "scanPage.legacyMode.prompt": "Your browser does not support live scanning",
   "scanPage.legacyMode.chooseImage": "Pick an image to scan",

--- a/src/i18n/et.json
+++ b/src/i18n/et.json
@@ -1,4 +1,8 @@
 {
+  "navigation.home": "Profiil",
+  "navigation.userCreation": "Kasutajad",
+  "navigation.addTest": "Testid",
+  "navigation.logOut": "Välju",
   "notFoundPage.heading": "Lehte ei leitud",
   "notFoundPage.imageAltText": "Naine õhupallidega minema lendamas",
   "notFoundPage.button": "Mine avalehele",
@@ -57,8 +61,7 @@
   "profileForm.button": "Edasi",
   "sharingCode.description": "Luba teisel kasutajal oma kood skaneerida, et turvaliselt oma tulemusi jagada",
   "sharingCode.button": "Skaneeri kood",
-  "viewingOtherProfileHeader.heading": "Patsiendi profiil",
-  "viewingOtherProfileHeader.button": "Sulge",
+  "viewingOtherProfileHeader.alert": "Vaatad teise kasutaja profiili. Oma profiilile naasmiseks vajuta \"Profiil\" lingil.",
   "scanPage.error.incorrectCode": "Vigane kood",
   "scanPage.legacyMode.prompt": "Teie veebilehitseja ei toeta reaalajas skaneerimist",
   "scanPage.legacyMode.chooseImage": "Vali pilt, mida skaneerida",

--- a/src/identity/IdentityPage.test.tsx
+++ b/src/identity/IdentityPage.test.tsx
@@ -258,9 +258,11 @@ describe('Identity page', () => {
 
     it('shows a special header that you are looking at another person', async () => {
       history.push('/users/mock-user-2');
-      await waitFor(() => expect(screen.queryByText(/patient profile/i)).not.toBeTruthy());
+      await waitFor(() =>
+        expect(screen.queryByText(/viewing another user's profile/i)).not.toBeInTheDocument()
+      );
       history.push('/users/mock-user');
-      await waitFor(() => expect(screen.queryByText(/patient profile/i)).toBeTruthy());
+      await screen.findByText(/viewing another user's profile/i);
     });
 
     it('does not show their QR code', async () => {

--- a/src/identity/IdentityPage.tsx
+++ b/src/identity/IdentityPage.tsx
@@ -136,13 +136,9 @@ export const IdentityPage = () => {
       <Route
         path={url}
         exact
-        render={() =>
-          isOwnUser ? (
-            <Redirect exact from={url} to={`${url}/share`} />
-          ) : (
-            <Redirect exact from={url} to={`${url}/tests`} />
-          )
-        }
+        render={() => (
+          <Redirect exact from={url} to={isOwnUser ? `${url}/share` : `${url}/tests`} />
+        )}
       />
     </>
   );

--- a/src/identity/IdentityPage.tsx
+++ b/src/identity/IdentityPage.tsx
@@ -6,7 +6,6 @@ import {
   Heading,
   NavLink as ThemeUiNavLink,
   Flex,
-  Container,
   NavLinkProps,
 } from 'theme-ui';
 import {
@@ -66,82 +65,81 @@ export const IdentityPage = () => {
 
   if (!user.profile) {
     return (
-      <Container variant="page">
+      <>
         <Heading as="h1" mb={5}>
           <Message>identityPage.heading</Message>
           {addressRequired && <Small>1/2</Small>}
         </Heading>
         <ProfileForm onComplete={createProfile} />
-      </Container>
+      </>
     );
   }
 
   if (!user.address && addressRequired) {
     return (
-      <Container variant="page">
+      <>
         <Heading as="h1" mb={5}>
           <Message>identityPage.heading</Message>
           {addressRequired && <Small>2/2</Small>}
         </Heading>
         <AddressForm onComplete={createAddress} />
-      </Container>
+      </>
     );
   }
 
   return (
     <>
       {!isOwnUser ? <ViewingOtherProfileHeader /> : null}
-      <Container variant="page" pt={isOwnUser ? undefined : 4}>
-        <Heading as="h1" mb={3}>
-          {user.profile.firstName} {user.profile.lastName}
-        </Heading>
-        <Text mb={5}>
-          {/* TODO: Add Estonian date formatting */}
-          <Message>identityPage.dateOfBirth</Message>:{' '}
-          {formatDate(new Date(user.profile.dateOfBirth))}
-        </Text>
-        {isOwnUser ? (
-          <Flex as="nav">
-            <NavLink
-              as={RouterNavLink}
-              to={`${url}/tests`}
-              variant="tab"
-              data-testid="test-result-link"
-            >
-              <TestIcon mr={1} /> <Message>identityPage.results</Message>
-            </NavLink>
-            <NavLink
-              as={RouterNavLink}
-              to={`${url}/profile`}
-              variant="tab"
-              data-testid="share-access-link"
-            >
-              <ProfileIcon mr={1} /> <Message>identityPage.share</Message>
-            </NavLink>
-          </Flex>
-        ) : null}
-        <Switch>
-          <Route path={`${url}/profile`} exact>
-            <Box mt={6}>
-              <SharingCode userId={userId} />
-            </Box>
-          </Route>
-          <Route path={`${url}/tests`} exact>
-            <TestList userId={userId} />
-          </Route>
-        </Switch>
-        <Route
-          path={url}
-          exact
-          render={() =>
-            isOwnUser ? (
-              <Redirect exact from={url} to={`${url}/profile`} />
-            ) : (
-              <Redirect exact from={url} to={`${url}/tests`} />
-            )
-          }
-        />
-      </Container>
+
+      <Heading as="h1" mb={3}>
+        {user.profile.firstName} {user.profile.lastName}
+      </Heading>
+      <Text mb={5}>
+        {/* TODO: Add Estonian date formatting */}
+        <Message>identityPage.dateOfBirth</Message>:{' '}
+        {formatDate(new Date(user.profile.dateOfBirth))}
+      </Text>
+      {isOwnUser ? (
+        <Flex as="nav">
+          <NavLink
+            as={RouterNavLink}
+            to={`${url}/tests`}
+            variant="tab"
+            data-testid="test-result-link"
+          >
+            <TestIcon mr={1} /> <Message>identityPage.results</Message>
+          </NavLink>
+          <NavLink
+            as={RouterNavLink}
+            to={`${url}/profile`}
+            variant="tab"
+            data-testid="share-access-link"
+          >
+            <ProfileIcon mr={1} /> <Message>identityPage.share</Message>
+          </NavLink>
+        </Flex>
+      ) : null}
+      <Switch>
+        <Route path={`${url}/profile`} exact>
+          <Box mt={6}>
+            <SharingCode userId={userId} />
+          </Box>
+        </Route>
+        <Route path={`${url}/tests`} exact>
+          <TestList userId={userId} />
+        </Route>
+      </Switch>
+      <Route
+        path={url}
+        exact
+        render={() =>
+          isOwnUser ? (
+            <Redirect exact from={url} to={`${url}/profile`} />
+          ) : (
+            <Redirect exact from={url} to={`${url}/tests`} />
+          )
+        }
+      />
     </>
   );
 };

--- a/src/identity/IdentityPage.tsx
+++ b/src/identity/IdentityPage.tsx
@@ -43,13 +43,16 @@ const NavLink = ThemeUiNavLink as React.FC<NavLinkProps & RouterNavLinkProps>;
 export const IdentityPage = () => {
   const {
     url,
-    params: { userId },
+    params: { userId: userIdFromParams },
   } = useRouteMatch();
-  const { user, update: updateUser } = useUser(userId);
   const { userId: authenticatedUserId } = useAuthentication();
+
+  const userId = userIdFromParams || authenticatedUserId;
+  const isOwnUser = userId === authenticatedUserId;
+
+  const { user, update: updateUser } = useUser(userId);
   const { addressRequired } = useConfig() || { addressRequired: false };
   const { formatDate } = useI18n();
-  const isOwnUser = userId === authenticatedUserId;
 
   if (!user) {
     return <Spinner variant="spinner.main" />;
@@ -94,11 +97,12 @@ export const IdentityPage = () => {
       <Heading as="h1" mb={3}>
         {user.profile.firstName} {user.profile.lastName}
       </Heading>
+
       <Text mb={5}>
-        {/* TODO: Add Estonian date formatting */}
         <Message>identityPage.dateOfBirth</Message>:{' '}
         {formatDate(new Date(user.profile.dateOfBirth))}
       </Text>
+
       {isOwnUser ? (
         <Flex as="nav">
           <NavLink
@@ -111,7 +115,7 @@ export const IdentityPage = () => {
           </NavLink>
           <NavLink
             as={RouterNavLink}
-            to={`${url}/profile`}
+            to={`${url}/share`}
             variant="tab"
             data-testid="share-access-link"
           >
@@ -120,7 +124,7 @@ export const IdentityPage = () => {
         </Flex>
       ) : null}
       <Switch>
-        <Route path={`${url}/profile`} exact>
+        <Route path={`${url}/share`} exact>
           <Box mt={6}>
             <SharingCode userId={userId} />
           </Box>
@@ -134,7 +138,7 @@ export const IdentityPage = () => {
         exact
         render={() =>
           isOwnUser ? (
-            <Redirect exact from={url} to={`${url}/profile`} />
+            <Redirect exact from={url} to={`${url}/share`} />
           ) : (
             <Redirect exact from={url} to={`${url}/tests`} />
           )

--- a/src/identity/ViewingOtherProfileHeader.tsx
+++ b/src/identity/ViewingOtherProfileHeader.tsx
@@ -1,28 +1,11 @@
 import React from 'react';
-import { Box, Flex, Heading, Button, ButtonProps } from 'theme-ui';
-import { Link, LinkProps } from 'react-router-dom';
-import { useAuthentication } from '../authentication';
+import { Alert } from 'theme-ui';
 import { Message } from 'retranslate';
 
-const LinkButton = Button as React.FC<ButtonProps & LinkProps>;
-// TODO: the styling on this header is very ad-hoc. Let's move it into the theme.
-// TODO: this maybe doesn't belong in this module. Where does it belong?
 export const ViewingOtherProfileHeader = () => {
-  const { userId } = useAuthentication();
   return (
-    <Box sx={{ backgroundColor: 'primary', color: 'background' }}>
-      <Flex px={3} py={2} sx={{ justifyContent: 'space-between', maxWidth: '600px' }} mx="auto">
-        <Heading as="h2" sx={{ lineHeight: 1.8 }}>
-          <Message>viewingOtherProfileHeader.heading</Message>
-        </Heading>
-        <LinkButton
-          as={Link}
-          to={`/users/${userId}`}
-          sx={{ border: '2px solid', borderColor: 'background' }}
-        >
-          <Message>viewingOtherProfileHeader.button</Message>
-        </LinkButton>
-      </Flex>
-    </Box>
+    <Alert mb={4}>
+      <Message>viewingOtherProfileHeader.alert</Message>
+    </Alert>
   );
 };

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,9 @@
+export const PERMISSIONS_REQUIRED_FOR_USER_CREATION_PAGE = ['BULK_CREATE_USERS'];
+export const PERMISSIONS_REQUIRED_FOR_ADD_TEST_TO_IDENTIFIER_PAGE = [
+  'CREATE_USERS',
+  'CREATE_TESTS_WITHOUT_ACCESS_PASS',
+];
+
+export const USER_CREATION_PATH = '/create-users';
+export const ADD_TEST_TO_IDENTIFIER_PATH = '/add-test';
+export const HOME_PATH = '/profile';

--- a/src/scanning/ScanPage.tsx
+++ b/src/scanning/ScanPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Text, Container, Heading, Box, Spinner, Button } from 'theme-ui';
+import { Text, Heading, Box, Spinner, Button } from 'theme-ui';
 import QrReader from 'react-qr-reader';
 import { useHistory } from 'react-router-dom';
 import { createAccessPass } from '../api';
@@ -44,7 +44,7 @@ export const ScanPage = () => {
 
   // TODO: use legacy mode if on iOS, but not on safari.
   return (
-    <Container sx={{ maxWidth: '600px' }}>
+    <>
       <Box mt={[0, 4]}>
         <QrReader
           ref={readerRef as any}
@@ -58,6 +58,7 @@ export const ScanPage = () => {
           legacyMode={legacyMode}
         />
       </Box>
+
       <Box
         px={3}
         pt={3}
@@ -88,6 +89,6 @@ export const ScanPage = () => {
         )}
         {loading ? <Spinner mx="auto" sx={{ display: 'block' }} /> : null}
       </Box>
-    </Container>
+    </>
   );
 };

--- a/src/staticPages.tsx
+++ b/src/staticPages.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link, LinkProps } from 'react-router-dom';
-import { Heading, Button, ButtonProps, Image, Container } from 'theme-ui';
+import { Heading, Button, ButtonProps, Image } from 'theme-ui';
 
 import balloonIllustration from './illustrations/balloons.svg';
 import { Message, useTranslations } from 'retranslate';
@@ -10,7 +10,7 @@ export const NotFoundPage = () => {
   const { translate } = useTranslations();
 
   return (
-    <Container variant="page">
+    <>
       <Heading as="h1" mb={5}>
         <Message>notFoundPage.heading</Message>
       </Heading>
@@ -18,6 +18,6 @@ export const NotFoundPage = () => {
       <NavButton as={Link} variant="block" to="/">
         <Message>notFoundPage.button</Message>
       </NavButton>
-    </Container>
+    </>
   );
 };

--- a/src/testing/AddTestPage.test.tsx
+++ b/src/testing/AddTestPage.test.tsx
@@ -120,9 +120,9 @@ describe('Test adding page', () => {
     it('shows you a special header to show you are looking at a patient', async () => {
       history.push('/users/mock-user/add-test');
       await waitFor(() => expect(screen.queryByText(/test type/i)).toBeTruthy());
-      expect(screen.queryByText(/patient profile/i)).not.toBeTruthy();
+      expect(screen.queryByText(/viewing another user's profile/i)).not.toBeInTheDocument();
       history.push('/users/mock-patient/add-test');
-      await waitFor(() => expect(screen.queryByText(/patient profile/i)).toBeTruthy());
+      await screen.findByText(/viewing another user's profile/i);
     });
 
     it('asks you to confirm their identity and then submits the test', async () => {

--- a/src/testing/AddTestPage.tsx
+++ b/src/testing/AddTestPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Heading, Select, Label, Container } from 'theme-ui';
+import { Heading, Select, Label } from 'theme-ui';
 import { Message } from 'retranslate';
 
 import { CreateTestCommand, createTest } from '../api';
@@ -60,9 +60,8 @@ export const AddTestPage = () => {
     return (
       <>
         {!isOwnUser ? <ViewingOtherProfileHeader /> : null}
-        <Container variant="page" pt={isOwnUser ? undefined : 4}>
-          <ConfirmIdentity userId={userId} loading={submitting} onConfirm={handleConfirmIdentity} />
-        </Container>
+
+        <ConfirmIdentity userId={userId} loading={submitting} onConfirm={handleConfirmIdentity} />
       </>
     );
   }
@@ -70,38 +69,37 @@ export const AddTestPage = () => {
   return (
     <>
       {!isOwnUser ? <ViewingOtherProfileHeader /> : null}
-      <Container variant="page" pt={isOwnUser ? undefined : 4}>
-        <Heading as="h1" mb={5}>
-          <Message>addTestPage.heading</Message>
-        </Heading>
-        {permittedTestTypes.length > 1 ? (
-          <>
-            <Label htmlFor="test-type">
-              <Message>addTestPage.testType.label</Message>
-            </Label>
-            <Select
-              id="test-type"
-              value={selectedTestTypeId}
-              onChange={(event) => setSelectedTestTypeId(event.target.value)}
-              required
-              mb={4}
-            >
-              {permittedTestTypes.map((type) => (
-                <option key={type.id} value={type.id}>
-                  {type.name}
-                </option>
-              ))}
-            </Select>
-          </>
-        ) : null}
-        {selectedTestType ? (
-          <AddTestForm
-            key={selectedTestType.id}
-            testType={selectedTestType}
-            onComplete={handleSubmit}
-          />
-        ) : null}
-      </Container>
+
+      <Heading as="h1" mb={5}>
+        <Message>addTestPage.heading</Message>
+      </Heading>
+      {permittedTestTypes.length > 1 ? (
+        <>
+          <Label htmlFor="test-type">
+            <Message>addTestPage.testType.label</Message>
+          </Label>
+          <Select
+            id="test-type"
+            value={selectedTestTypeId}
+            onChange={(event) => setSelectedTestTypeId(event.target.value)}
+            required
+            mb={4}
+          >
+            {permittedTestTypes.map((type) => (
+              <option key={type.id} value={type.id}>
+                {type.name}
+              </option>
+            ))}
+          </Select>
+        </>
+      ) : null}
+      {selectedTestType ? (
+        <AddTestForm
+          key={selectedTestType.id}
+          testType={selectedTestType}
+          onComplete={handleSubmit}
+        />
+      ) : null}
     </>
   );
 };

--- a/src/testing/AddTestToIdentifierPage.tsx
+++ b/src/testing/AddTestToIdentifierPage.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect, useState } from 'react';
 import { Message, useTranslations } from 'retranslate';
-import { Box, Label, Heading, Container, Button, Alert, Input, Text, Select } from 'theme-ui';
+import { Box, Label, Heading, Button, Alert, Input, Text, Select } from 'theme-ui';
 import { useFormik } from 'formik';
 import * as yup from 'yup';
 
@@ -88,7 +88,7 @@ export const AddTestToIdentifierPage: FC = () => {
     form.touched[key] && form.errors[key] ? <Text>{form.errors[key]}</Text> : null;
 
   return (
-    <Container variant="page">
+    <>
       <Heading as="h1" mb={4}>
         <Message>addTestToIdentifierPage.heading</Message>
       </Heading>
@@ -148,6 +148,6 @@ export const AddTestToIdentifierPage: FC = () => {
           {error.message}
         </Alert>
       )}
-    </Container>
+    </>
   );
 };

--- a/src/testing/ConfirmIdentity.tsx
+++ b/src/testing/ConfirmIdentity.tsx
@@ -46,7 +46,6 @@ export const ConfirmIdentity = ({
       </Heading>
       <Text mb={4}>
         <Message>confirmIdentity.dateOfBirth</Message>: {formatDate(new Date(dateOfBirth))}
-        {/* TODO: Add Estonian date formatting  */}
       </Text>
       {text(address1)}
       {text(address2)}

--- a/src/testing/TestDetailPage.tsx
+++ b/src/testing/TestDetailPage.tsx
@@ -39,7 +39,6 @@ export const TestDetailPage = () => {
         <Message>testDetailPage.heading</Message>
       </Heading>
       <Text mb={2}>
-        {/* TODO: Add Estonian date formatting */}
         <Message>testDetailPage.date</Message>: {formatDate(new Date(test!.creationTime))}
       </Text>
       {test.resultsInterpretations?.map((interpretation, index) => (

--- a/src/testing/TestDetailPage.tsx
+++ b/src/testing/TestDetailPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import { Container, Heading, Spinner, Text, Divider, Flex, Box } from 'theme-ui';
+import { Heading, Spinner, Text, Divider, Flex, Box } from 'theme-ui';
 import { useTranslations, Message } from 'retranslate';
 
 import { useI18n } from '../common';
@@ -34,7 +34,7 @@ export const TestDetailPage = () => {
   });
 
   return (
-    <Container variant="page">
+    <>
       <Heading as="h1" mb={2}>
         <Message>testDetailPage.heading</Message>
       </Heading>
@@ -82,6 +82,6 @@ export const TestDetailPage = () => {
           {test.results.notes}
         </>
       ) : null}
-    </Container>
+    </>
   );
 };

--- a/src/testing/TestList.tsx
+++ b/src/testing/TestList.tsx
@@ -45,7 +45,6 @@ export const TestList = ({ userId }: { userId: string }) => {
                 >
                   <Box>
                     <Heading as="h3" mb={2}>
-                      {/* TODO: Add Estonian date formatting */}
                       {formatDate(new Date(test.creationTime))}
                     </Heading>
                     {test.resultsInterpretations?.map((interpretation, index) => (

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -19,6 +19,9 @@ const theme = {
     ...baseTheme.colors,
     primary: '#096DD9',
   },
+  sizes: {
+    pageWidth: '600px',
+  },
   links: {
     tab: {
       textAlign: 'center',
@@ -41,8 +44,8 @@ const theme = {
   },
   layout: {
     page: {
-      maxWidth: '600px',
-      paddingTop: 6,
+      maxWidth: 'pageWidth',
+      paddingTop: 4,
       paddingBottom: 5,
       paddingRight: 3,
       paddingLeft: 3,


### PR DESCRIPTION
## Context

We sometimes have more views than just the home/profile view — user creation and adding test to identifier. Currently, there are no links to these pages in the experience. In addition, it's impossible to log out from the UI.

## Changes

A navigation bar is added with an always-present _Home_ link and two links which may or may not be shown depending on the permissions — _Create users_ and _Add test_. In addition, a _Log out_ button is added.

To accommodate this, the _viewing other profile header_ is redesigned to not look like a navbar, but an alert instead, and the _page container_ wrapper is moved to the `App` level from all components.

The URL for the logged-in user's test results and sharing code is also switched from `/users/${userId}/*` to `/profile/*` to ensure the navigation's active states work correctly.

In addition, date formatting TODOs have been removed, as it was done in https://github.com/cov-clear/web/pull/66, and the page width variable has been moved to the Theme-UI theme.

## Screenshot

<img src="https://user-images.githubusercontent.com/5443561/81478018-74d75080-9223-11ea-8b95-c5d9794d5111.png" width="375" />