### PR TITLE
Use translation key for logout copy

### DIFF
--- a/src/Navigation/Navigation.tsx
+++ b/src/Navigation/Navigation.tsx
@@ -54,7 +54,7 @@ export const Navigation = () => {
       </Box>
 
       <ThemeUiNavLink p={2} onClick={signOut} href="/">
-        Log out
+        <Message>navigation.logOut</Message>
       </ThemeUiNavLink>
     </Flex>
   );


### PR DESCRIPTION
## Context

The logout button always had English copy, because we forgot to use the translation key there.

## Changes

Translation key is used for logout button.