### PR TITLE
Always show test type input, fix padding and styling

### DIFF
--- a/src/testing/AddTestToIdentifierPage.tsx
+++ b/src/testing/AddTestToIdentifierPage.tsx
@@ -107,26 +107,24 @@ export const AddTestToIdentifierPage: FC = () => {
           {fieldError('identifier')}
         </Box>
 
-        {permittedTestTypes.length > 1 && (
-          <>
-            <Label htmlFor="test-type">
-              <Message>addTestPage.testType.label</Message>
-            </Label>
-            <Select
-              id="test-type"
-              value={selectedTestTypeId}
-              onChange={(event) => setSelectedTestTypeId(event.target.value)}
-              required
-              mb={4}
-            >
-              {permittedTestTypes.map((type) => (
-                <option key={type.id} value={type.id}>
-                  {type.name}
-                </option>
-              ))}
-            </Select>
-          </>
-        )}
+        <Box>
+          <Label htmlFor="test-type">
+            <Message>addTestPage.testType.label</Message> *
+          </Label>
+
+          <Select
+            id="test-type"
+            value={selectedTestTypeId}
+            onChange={(event) => setSelectedTestTypeId(event.target.value)}
+            required
+          >
+            {permittedTestTypes.map((type) => (
+              <option key={type.id} value={type.id}>
+                {type.name}
+              </option>
+            ))}
+          </Select>
+        </Box>
 
         {selectedTestType && <TestFields form={form} testType={selectedTestType} />}
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -135,6 +135,9 @@ const theme = {
     textarea: {
       borderColor: 'gray',
     },
+    select: {
+      borderColor: 'gray',
+    },
     label: {
       color: '#262626',
     },


### PR DESCRIPTION
## Context

When demoing the _add test to identifier page_, we noticed a few things with the test type field:
1. The padding between the label and the select element is too large
1. It's not marked as required with an asterisk
1. Its border is a different colour from the input and textarea

In addition, we realised that when there's just _one_ permitted test type, the name won't be shown at all, as we only show the select element when there's more than 1.

## Changes

The issues are now fixed.

**Before/after**

<img src="https://user-images.githubusercontent.com/5443561/81562314-4d0bf800-939d-11ea-9e86-7bb20d22aa72.png" width="200" /><img src="https://user-images.githubusercontent.com/5443561/81562317-4da48e80-939d-11ea-9c51-2dc729fe1e56.png" width="200" />
