### PR TITLE
Support const properties in JSON schema

### DIFF
--- a/src/testHelpers.tsx
+++ b/src/testHelpers.tsx
@@ -71,6 +71,10 @@ export function antibodyTestType(): TestType {
           type: 'boolean',
           description: 'Indicator if sample shows IgM positive',
         },
+        msa: {
+          title: 'MSA',
+          const: '123456',
+        },
       },
     },
     neededPermissionToAddResults: 'CREATE_TESTS_WITHOUT_ACCESS_PASS',

--- a/src/testing/AddTestToIdentifierPage.test.tsx
+++ b/src/testing/AddTestToIdentifierPage.test.tsx
@@ -114,6 +114,7 @@ describe(AddTestToIdentifierPage, () => {
             c: true,
             igg: false,
             igm: true,
+            msa: antibodyTestType().resultsSchema.properties.msa.const,
           },
           notes: 'Some notes',
         },

--- a/src/testing/TestFields.tsx
+++ b/src/testing/TestFields.tsx
@@ -21,6 +21,10 @@ export const TestFields: FC<TestFieldsProps> = ({ form, testType }) => {
       {Object.entries(testType.resultsSchema.properties).map(([key, value]) => {
         const isKeyRequired = testType.resultsSchema.required?.includes(key);
 
+        if (value.const) {
+          return null;
+        }
+
         if (value.oneOf) {
           return (
             <Box key={key}>
@@ -139,7 +143,11 @@ function validationSchema({ type, oneOf }: FieldSchema, required: boolean) {
   return validation;
 }
 
-function initialPropertyValue({ type, oneOf }: FieldSchema) {
+function initialPropertyValue({ type, oneOf, const: constValue }: FieldSchema) {
+  if (constValue) {
+    return constValue;
+  }
+
   if (oneOf) {
     return null;
   }


### PR DESCRIPTION
## Context

We need to show some additional information connected to a test type on the test result page.

## Changes

`const` property support is added to the schema — nothing will be rendered in the form, but the constant value will be sent in the payload, allowing us to show the additional information on the test result page.