### PR TITLE
Hide add test result button when own profile

### DIFF
--- a/src/identity/IdentityPage.test.tsx
+++ b/src/identity/IdentityPage.test.tsx
@@ -66,7 +66,8 @@ describe('Identity page', () => {
       userId: 'mock-user',
       authenticate: jest.fn(),
       signOut,
-      hasPermission: (key: string) => key === 'mock-permission',
+      hasPermission: (key: string) =>
+        key === 'mock-permission' || key === 'ADD_TAKE_HOME_TEST_RESULT',
     }));
     fetchTestsMock.mockImplementation(() => Promise.resolve([]));
     fetchTestTypesMock.mockImplementation(() => Promise.resolve([aNonPermittedTestType()]));

--- a/src/testing/TestList.tsx
+++ b/src/testing/TestList.tsx
@@ -6,6 +6,7 @@ import { Message } from 'retranslate';
 import { useI18n } from '../common';
 import { Plus as PlusIcon, Caret } from '../icons';
 import { useTests, useTestTypes } from '../resources';
+import { useAuthentication } from '../authentication';
 
 import { InterpretationBadge } from './InterpretationBadge';
 
@@ -13,6 +14,7 @@ const LinkButton = Button as React.FC<ButtonProps & LinkProps>;
 const LinkFlex = Flex as React.FC<FlexProps & LinkProps>;
 
 export const TestList = ({ userId }: { userId: string }) => {
+  const { userId: authenticatedUserId, hasPermission } = useAuthentication();
   const { loading: loadingTests, tests } = useTests(userId);
   const { permittedTestTypes, loading: loadingTestTypes } = useTestTypes();
   const { formatDate } = useI18n();
@@ -20,6 +22,10 @@ export const TestList = ({ userId }: { userId: string }) => {
   if (loadingTests || loadingTestTypes) {
     return <Spinner mx="auto" mt={6} sx={{ display: 'block' }} />;
   }
+
+  const isOwnUser = userId === authenticatedUserId;
+  const showAddTestResultButton =
+    permittedTestTypes.length > 0 && (!isOwnUser || hasPermission('ADD_TAKE_HOME_TEST_RESULT'));
 
   return (
     <>
@@ -58,11 +64,12 @@ export const TestList = ({ userId }: { userId: string }) => {
           })}
         </Box>
       )}
-      {permittedTestTypes.length ? (
+
+      {showAddTestResultButton && (
         <LinkButton as={Link} to={`/users/${userId}/add-test`} variant="block" mt={4}>
           <PlusIcon mr={1} /> <Message>testList.button</Message>
         </LinkButton>
-      ) : null}
+      )}
     </>
   );
 };


### PR DESCRIPTION
## Context

Seeing the _Add test result_ button may be misleading to test administrators, and they may accidentally add a test result to themselves.

## Changes

The button is only shown if not own profile or if the user has a permission to add take home test.