### PR TITLE
Validate forms on submit, restyle validation messages

### DIFF
--- a/src/admin/BulkUserCreationPage.tsx
+++ b/src/admin/BulkUserCreationPage.tsx
@@ -78,7 +78,9 @@ const BulkUserCreationPage: FC = () => {
   });
 
   const fieldError = (key: keyof FormFields) =>
-    form.submitCount > 0 && form.errors[key] ? <Text>{form.errors[key]}</Text> : null;
+    form.submitCount > 0 && form.errors[key] ? (
+      <Text variant="validation">{form.errors[key]}</Text>
+    ) : null;
 
   return (
     <>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -99,5 +99,6 @@
   "addTestToIdentifierPage.form.identifier.invalid.magicLink": "Please check the email address",
   "addTestToIdentifierPage.form.identifier.invalid.estonianId": "Please check the identification code",
   "addTestToIdentifierPage.button": "Add test result",
-  "addTestToIdentifierPage.success": "Test result for {{ identifier }} added."
+  "addTestToIdentifierPage.success": "Test result for {{ identifier }} added.",
+  "testFields.error.generic": "Please check the input"
 }

--- a/src/i18n/et.json
+++ b/src/i18n/et.json
@@ -99,5 +99,6 @@
   "addTestToIdentifierPage.form.identifier.invalid.magicLink": "Palun kontrolli meiliaadressi",
   "addTestToIdentifierPage.form.identifier.invalid.estonianId": "Palun kontrolli isikukoodi",
   "addTestToIdentifierPage.button": "Lisa testitulemus",
-  "addTestToIdentifierPage.success": "Testitulemus isikule {{ identifier }} lisatud."
+  "addTestToIdentifierPage.success": "Testitulemus isikule {{ identifier }} lisatud.",
+  "testFields.error.generic": "Palun kontrolli sisestatud väärtust"
 }

--- a/src/identity/AddressForm.tsx
+++ b/src/identity/AddressForm.tsx
@@ -50,7 +50,9 @@ export const AddressForm = ({ onComplete }: { onComplete: (address: Address) => 
   });
 
   const fieldError = (key: keyof AddressFormFields) =>
-    form.touched[key] && form.errors[key] ? <Text>{form.errors[key]}</Text> : null;
+    form.submitCount > 0 && form.errors[key] ? (
+      <Text variant="validation">{form.errors[key]}</Text>
+    ) : null;
 
   const field = (name: keyof AddressFormFields, label: string) => {
     const id = `identity-${name}`;

--- a/src/identity/ProfileForm.tsx
+++ b/src/identity/ProfileForm.tsx
@@ -46,7 +46,9 @@ export const ProfileForm = ({ onComplete }: { onComplete: (profile: Profile) => 
   });
 
   const fieldError = (key: keyof ProfileFormFields) =>
-    form.touched[key] && form.errors[key] ? <Text>{form.errors[key]}</Text> : null;
+    form.submitCount > 0 && form.errors[key] ? (
+      <Text variant="validation">{form.errors[key]}</Text>
+    ) : null;
 
   return (
     <AnyBox as="form" sx={{ display: 'grid', gridGap: 4 }} onSubmit={form.handleSubmit}>

--- a/src/testing/AddTestToIdentifierPage.tsx
+++ b/src/testing/AddTestToIdentifierPage.tsx
@@ -85,7 +85,9 @@ export const AddTestToIdentifierPage: FC = () => {
   });
 
   const fieldError = (key: keyof FormFields) =>
-    form.touched[key] && form.errors[key] ? <Text>{form.errors[key]}</Text> : null;
+    form.submitCount > 0 && form.errors[key] ? (
+      <Text variant="validation">{form.errors[key]}</Text>
+    ) : null;
 
   return (
     <>
@@ -128,7 +130,7 @@ export const AddTestToIdentifierPage: FC = () => {
 
         {selectedTestType && <TestFields form={form} testType={selectedTestType} />}
 
-        <Button variant="block" type="submit" disabled={!form.isValid || creating}>
+        <Button variant="block" type="submit" disabled={creating}>
           <Message>addTestToIdentifierPage.button</Message>
         </Button>
       </AnyBox>

--- a/src/testing/TestFields.tsx
+++ b/src/testing/TestFields.tsx
@@ -13,7 +13,11 @@ interface TestFieldsProps {
 
 export const TestFields: FC<TestFieldsProps> = ({ form, testType }) => {
   const fieldError = (key: keyof TestType['resultsSchema']['properties']) =>
-    form.touched[key] && form.errors[key] ? <Text>{form.errors[key]}</Text> : null;
+    form.submitCount > 0 && form.errors[key] ? (
+      <Text variant="validation">
+        <Message>testFields.error.generic</Message>
+      </Text>
+    ) : null;
 
   // TODO: Extract generic JSON schema generator
   return (

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -18,6 +18,8 @@ const theme = {
   colors: {
     ...baseTheme.colors,
     primary: '#096DD9',
+    success: '#52c41a', // Primary green from https://ant.design/docs/spec/colors
+    error: '#f5222d', // Primary red from https://ant.design/docs/spec/colors
   },
   sizes: {
     pageWidth: '600px',
@@ -102,10 +104,10 @@ const theme = {
       paddingRight: 4,
     },
     success: {
-      background: '#52c41a', // Primary green from https://ant.design/docs/spec/colors
+      backgroundColor: 'success',
     },
     error: {
-      background: '#f5222d', // Primary red from https://ant.design/docs/spec/colors
+      backgroundColor: 'error',
     },
   },
   badges: {
@@ -146,6 +148,12 @@ const theme = {
     ...baseTheme.styles,
     hr: {
       borderBottom: '1px solid #DEDEDE',
+    },
+  },
+  text: {
+    validation: {
+      color: 'error',
+      fontSize: 1,
     },
   },
 };


### PR DESCRIPTION
## Context

The current form experience is not great, as the immediate validation messages make the rest of the form jump. In addition, the form validation messages have the body text colour and are not noticeable.

## Changes

* the validation errors are only shown after the first submit to provide a more typical experience
* the validation errors are shown as smaller, red text

## Screenshots

![localhost_3000_add-test(iPhone 6_7_8) (5)](https://user-images.githubusercontent.com/5443561/81854579-cc98f300-9566-11ea-9fa1-15aae908709a.png)
