### PR TITLE
Add scan callback page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { NotFoundPage } from './staticPages';
 
 import { IdentityPage } from './identity';
 import { AddTestPage, TestDetailPage, AddTestToIdentifierPage } from './testing';
+import { ScanCallbackPage } from './scanning';
 import { BulkUserCreationPage } from './admin';
 import { useConfig } from './common';
 import { Language } from './api';
@@ -121,6 +122,9 @@ const App = () => {
                   </AuthenticatedRoute>
                   <AuthenticatedRoute path="/scan" exact>
                     <ScanPage />
+                  </AuthenticatedRoute>
+                  <AuthenticatedRoute path="/scan-callback" exact>
+                    <ScanCallbackPage />
                   </AuthenticatedRoute>
                   <AuthenticatedRoute
                     path="/add-test"

--- a/src/identity/IdentityPage.test.tsx
+++ b/src/identity/IdentityPage.test.tsx
@@ -108,7 +108,9 @@ describe('Identity page', () => {
 
     it('loads and shows their sharing code in a qr code', async () => {
       await waitFor(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
-      expect(screen.queryByText(/Mock QRCode: mock-sharing-code/i)).toBeInTheDocument();
+      expect(
+        screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\/mock-sharing-code/i)
+      ).toBeInTheDocument();
     });
 
     it('automatically refreshes the sharing code when it is about to expire', async () => {
@@ -121,7 +123,9 @@ describe('Identity page', () => {
         </Router>
       );
       await waitFor(() => expect(screen.queryByText(/first middle last/i)).toBeInTheDocument());
-      expect(screen.queryByText(/Mock QRCode: mock-sharing-code/i)).toBeInTheDocument();
+      expect(
+        screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\/mock-sharing-code/i)
+      ).toBeInTheDocument();
       createSharingCodeForUserIdMock.mockImplementation(async () => {
         return { code: 'mock-sharing-code-2', expiryTime: secondsFromNow(90).toISOString() };
       });
@@ -132,7 +136,9 @@ describe('Identity page', () => {
         await nextTick();
       });
       expect(createSharingCodeForUserIdMock).toHaveBeenCalledTimes(2);
-      expect(screen.queryByText(/Mock QRCode: mock-sharing-code-2/i)).toBeInTheDocument();
+      expect(
+        screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\/mock-sharing-code-2/i)
+      ).toBeInTheDocument();
       await act(async () => {
         MockDate.set(secondsFromNow(10));
         jest.advanceTimersToNextTimer();
@@ -143,17 +149,23 @@ describe('Identity page', () => {
 
     it('lets you switch to the tests tab', async () => {
       await waitFor(() =>
-        expect(screen.queryByText(/Mock QRCode: mock-sharing-code/i)).toBeTruthy()
+        expect(
+          screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\/mock-sharing-code/i)
+        ).toBeTruthy()
       );
       expect(screen.queryByText(/test results will appear here/i)).toBeFalsy();
       fireEvent.click(getTestResultsLink());
       await waitFor(() =>
         expect(screen.queryByText(/test results will appear here/i)).toBeTruthy()
       );
-      expect(screen.queryByText(/Mock QRCode: mock-sharing-code/i)).toBeFalsy();
+      expect(
+        screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\/mock-sharing-code/i)
+      ).toBeFalsy();
       fireEvent.click(getShareAccessLink());
       await waitFor(() =>
-        expect(screen.queryByText(/Mock QRCode: mock-sharing-code/i)).toBeTruthy()
+        expect(
+          screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\/mock-sharing-code/i)
+        ).toBeTruthy()
       );
       expect(screen.queryByText(/test results will appear here/i)).toBeFalsy();
     });
@@ -194,23 +206,31 @@ describe('Identity page', () => {
 
     it('lets you navigate with browser history', async () => {
       await waitFor(() =>
-        expect(screen.queryByText(/Mock QRCode: mock-sharing-code/i)).toBeTruthy()
+        expect(
+          screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\/mock-sharing-code/i)
+        ).toBeTruthy()
       );
       fireEvent.click(getTestResultsLink());
       await waitFor(() =>
         expect(screen.queryByText(/test results will appear here/i)).toBeTruthy()
       );
-      expect(screen.queryByText(/Mock QRCode: mock-sharing-code/i)).toBeFalsy();
+      expect(
+        screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\/mock-sharing-code/i)
+      ).toBeFalsy();
       history.goBack();
       await waitFor(() =>
-        expect(screen.queryByText(/Mock QRCode: mock-sharing-code/i)).toBeTruthy()
+        expect(
+          screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\/mock-sharing-code/i)
+        ).toBeTruthy()
       );
       expect(screen.queryByText(/test results will appear here/i)).toBeFalsy();
       history.goForward();
       await waitFor(() =>
         expect(screen.queryByText(/test results will appear here/i)).toBeTruthy()
       );
-      expect(screen.queryByText(/Mock QRCode: mock-sharing-code/i)).toBeFalsy();
+      expect(
+        screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\/mock-sharing-code/i)
+      ).toBeFalsy();
     });
 
     it('lets you go to the scan page', async () => {

--- a/src/identity/IdentityPage.test.tsx
+++ b/src/identity/IdentityPage.test.tsx
@@ -109,7 +109,7 @@ describe('Identity page', () => {
     it('loads and shows their sharing code in a qr code', async () => {
       await waitFor(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
       expect(
-        screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\/mock-sharing-code/i)
+        screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\?sharingCode=mock-sharing-code/i)
       ).toBeInTheDocument();
     });
 
@@ -124,7 +124,7 @@ describe('Identity page', () => {
       );
       await waitFor(() => expect(screen.queryByText(/first middle last/i)).toBeInTheDocument());
       expect(
-        screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\/mock-sharing-code/i)
+        screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\?sharingCode=mock-sharing-code/i)
       ).toBeInTheDocument();
       createSharingCodeForUserIdMock.mockImplementation(async () => {
         return { code: 'mock-sharing-code-2', expiryTime: secondsFromNow(90).toISOString() };
@@ -137,7 +137,9 @@ describe('Identity page', () => {
       });
       expect(createSharingCodeForUserIdMock).toHaveBeenCalledTimes(2);
       expect(
-        screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\/mock-sharing-code-2/i)
+        screen.queryByText(
+          /Mock QRCode: http:\/\/localhost\/scan\?sharingCode=mock-sharing-code-2/i
+        )
       ).toBeInTheDocument();
       await act(async () => {
         MockDate.set(secondsFromNow(10));
@@ -150,7 +152,9 @@ describe('Identity page', () => {
     it('lets you switch to the tests tab', async () => {
       await waitFor(() =>
         expect(
-          screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\/mock-sharing-code/i)
+          screen.queryByText(
+            /Mock QRCode: http:\/\/localhost\/scan\?sharingCode=mock-sharing-code/i
+          )
         ).toBeTruthy()
       );
       expect(screen.queryByText(/test results will appear here/i)).toBeFalsy();
@@ -159,12 +163,14 @@ describe('Identity page', () => {
         expect(screen.queryByText(/test results will appear here/i)).toBeTruthy()
       );
       expect(
-        screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\/mock-sharing-code/i)
+        screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\?sharingCode=mock-sharing-code/i)
       ).toBeFalsy();
       fireEvent.click(getShareAccessLink());
       await waitFor(() =>
         expect(
-          screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\/mock-sharing-code/i)
+          screen.queryByText(
+            /Mock QRCode: http:\/\/localhost\/scan\?sharingCode=mock-sharing-code/i
+          )
         ).toBeTruthy()
       );
       expect(screen.queryByText(/test results will appear here/i)).toBeFalsy();
@@ -207,7 +213,9 @@ describe('Identity page', () => {
     it('lets you navigate with browser history', async () => {
       await waitFor(() =>
         expect(
-          screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\/mock-sharing-code/i)
+          screen.queryByText(
+            /Mock QRCode: http:\/\/localhost\/scan\?sharingCode=mock-sharing-code/i
+          )
         ).toBeTruthy()
       );
       fireEvent.click(getTestResultsLink());
@@ -215,12 +223,14 @@ describe('Identity page', () => {
         expect(screen.queryByText(/test results will appear here/i)).toBeTruthy()
       );
       expect(
-        screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\/mock-sharing-code/i)
+        screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\?sharingCode=mock-sharing-code/i)
       ).toBeFalsy();
       history.goBack();
       await waitFor(() =>
         expect(
-          screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\/mock-sharing-code/i)
+          screen.queryByText(
+            /Mock QRCode: http:\/\/localhost\/scan\?sharingCode=mock-sharing-code/i
+          )
         ).toBeTruthy()
       );
       expect(screen.queryByText(/test results will appear here/i)).toBeFalsy();
@@ -229,7 +239,7 @@ describe('Identity page', () => {
         expect(screen.queryByText(/test results will appear here/i)).toBeTruthy()
       );
       expect(
-        screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\/mock-sharing-code/i)
+        screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\?sharingCode=mock-sharing-code/i)
       ).toBeFalsy();
     });
 

--- a/src/identity/IdentityPage.test.tsx
+++ b/src/identity/IdentityPage.test.tsx
@@ -109,7 +109,9 @@ describe('Identity page', () => {
     it('loads and shows their sharing code in a qr code', async () => {
       await waitFor(() => expect(screen.queryByText(/first middle last/i)).toBeTruthy());
       expect(
-        screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\?sharingCode=mock-sharing-code/i)
+        screen.queryByText(
+          /Mock QRCode: http:\/\/localhost\/scan-callback\?sharingCode=mock-sharing-code/i
+        )
       ).toBeInTheDocument();
     });
 
@@ -124,7 +126,9 @@ describe('Identity page', () => {
       );
       await waitFor(() => expect(screen.queryByText(/first middle last/i)).toBeInTheDocument());
       expect(
-        screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\?sharingCode=mock-sharing-code/i)
+        screen.queryByText(
+          /Mock QRCode: http:\/\/localhost\/scan-callback\?sharingCode=mock-sharing-code/i
+        )
       ).toBeInTheDocument();
       createSharingCodeForUserIdMock.mockImplementation(async () => {
         return { code: 'mock-sharing-code-2', expiryTime: secondsFromNow(90).toISOString() };
@@ -138,7 +142,7 @@ describe('Identity page', () => {
       expect(createSharingCodeForUserIdMock).toHaveBeenCalledTimes(2);
       expect(
         screen.queryByText(
-          /Mock QRCode: http:\/\/localhost\/scan\?sharingCode=mock-sharing-code-2/i
+          /Mock QRCode: http:\/\/localhost\/scan-callback\?sharingCode=mock-sharing-code-2/i
         )
       ).toBeInTheDocument();
       await act(async () => {
@@ -153,7 +157,7 @@ describe('Identity page', () => {
       await waitFor(() =>
         expect(
           screen.queryByText(
-            /Mock QRCode: http:\/\/localhost\/scan\?sharingCode=mock-sharing-code/i
+            /Mock QRCode: http:\/\/localhost\/scan-callback\?sharingCode=mock-sharing-code/i
           )
         ).toBeTruthy()
       );
@@ -163,13 +167,15 @@ describe('Identity page', () => {
         expect(screen.queryByText(/test results will appear here/i)).toBeTruthy()
       );
       expect(
-        screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\?sharingCode=mock-sharing-code/i)
+        screen.queryByText(
+          /Mock QRCode: http:\/\/localhost\/scan-callback\?sharingCode=mock-sharing-code/i
+        )
       ).toBeFalsy();
       fireEvent.click(getShareAccessLink());
       await waitFor(() =>
         expect(
           screen.queryByText(
-            /Mock QRCode: http:\/\/localhost\/scan\?sharingCode=mock-sharing-code/i
+            /Mock QRCode: http:\/\/localhost\/scan-callback\?sharingCode=mock-sharing-code/i
           )
         ).toBeTruthy()
       );
@@ -214,7 +220,7 @@ describe('Identity page', () => {
       await waitFor(() =>
         expect(
           screen.queryByText(
-            /Mock QRCode: http:\/\/localhost\/scan\?sharingCode=mock-sharing-code/i
+            /Mock QRCode: http:\/\/localhost\/scan-callback\?sharingCode=mock-sharing-code/i
           )
         ).toBeTruthy()
       );
@@ -223,13 +229,15 @@ describe('Identity page', () => {
         expect(screen.queryByText(/test results will appear here/i)).toBeTruthy()
       );
       expect(
-        screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\?sharingCode=mock-sharing-code/i)
+        screen.queryByText(
+          /Mock QRCode: http:\/\/localhost\/scan-callback\?sharingCode=mock-sharing-code/i
+        )
       ).toBeFalsy();
       history.goBack();
       await waitFor(() =>
         expect(
           screen.queryByText(
-            /Mock QRCode: http:\/\/localhost\/scan\?sharingCode=mock-sharing-code/i
+            /Mock QRCode: http:\/\/localhost\/scan-callback\?sharingCode=mock-sharing-code/i
           )
         ).toBeTruthy()
       );
@@ -239,7 +247,9 @@ describe('Identity page', () => {
         expect(screen.queryByText(/test results will appear here/i)).toBeTruthy()
       );
       expect(
-        screen.queryByText(/Mock QRCode: http:\/\/localhost\/scan\?sharingCode=mock-sharing-code/i)
+        screen.queryByText(
+          /Mock QRCode: http:\/\/localhost\/scan-callback\?sharingCode=mock-sharing-code/i
+        )
       ).toBeFalsy();
     });
 

--- a/src/identity/SharingCode.tsx
+++ b/src/identity/SharingCode.tsx
@@ -17,7 +17,7 @@ export const SharingCode = ({ userId }: { userId: string }) => {
     return <Spinner sx={{ display: 'block' }} mx="auto" />;
   }
 
-  return <QRCode value={sharingCode!.code} />;
+  return <QRCode value={buildSharingUrl(sharingCode!.code)} />;
 };
 
 const QRCode = ({ value }: { value: string }) => {
@@ -50,3 +50,7 @@ const QRCode = ({ value }: { value: string }) => {
     </Measure>
   );
 };
+
+function buildSharingUrl(sharingCode: string): string {
+  return `${window.location.origin}/scan/${sharingCode}`;
+}

--- a/src/identity/SharingCode.tsx
+++ b/src/identity/SharingCode.tsx
@@ -52,5 +52,5 @@ const QRCode = ({ value }: { value: string }) => {
 };
 
 function buildSharingUrl(sharingCode: string): string {
-  return `${window.location.origin}/scan/${sharingCode}`;
+  return `${window.location.origin}/scan?sharingCode=${encodeURIComponent(sharingCode)}`;
 }

--- a/src/identity/SharingCode.tsx
+++ b/src/identity/SharingCode.tsx
@@ -52,5 +52,5 @@ const QRCode = ({ value }: { value: string }) => {
 };
 
 function buildSharingUrl(sharingCode: string): string {
-  return `${window.location.origin}/scan?sharingCode=${encodeURIComponent(sharingCode)}`;
+  return `${window.location.origin}/scan-callback?sharingCode=${encodeURIComponent(sharingCode)}`;
 }

--- a/src/scanning/ScanCallbackPage.test.tsx
+++ b/src/scanning/ScanCallbackPage.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Router, Route } from 'react-router-dom';
+import { createMemoryHistory, History } from 'history';
+import { render, waitFor } from '@testing-library/react';
+import nock from 'nock';
+
+import { ScanCallbackPage } from '.';
+
+jest.mock('../authentication', () => ({
+  useAuthentication: () => ({
+    userId: 'mock-user-id',
+    token: 'some-token',
+  }),
+}));
+
+const mockSharingCode = 'dca03948-51d0-4501-aabb-39bd08a0e60e';
+
+describe('Scan callback page', () => {
+  let history: History;
+  beforeEach(() => {
+    history = createMemoryHistory();
+    render(
+      <Router history={history}>
+        <Route path="/scan-callback" exact>
+          <ScanCallbackPage />
+        </Route>
+      </Router>
+    );
+  });
+
+  it('creates and uses an access pass', async () => {
+    nock(/./)
+      .post('/api/v1/users/mock-user-id/access-passes', { code: mockSharingCode })
+      .matchHeader('Authorization', 'Bearer some-token')
+      .reply(201, { userId: 'mock-patient-id', expiryTime: new Date().toISOString() });
+
+    history.push(`/scan-callback?sharingCode=${mockSharingCode}`);
+
+    await waitFor(() => expect(history.location.pathname).toBe('/users/mock-patient-id'));
+  });
+
+  it('redirects to scan page when sharing code is invalid', async () => {
+    history.push(`/scan-callback?sharingCode=wrong-code`);
+
+    await waitFor(() => expect(history.location.pathname).toBe('/scan'));
+  });
+
+  it('redirects to scan page when creating access pass fails', async () => {
+    nock(/./)
+      .post('/api/v1/users/mock-user-id/access-passes', { code: mockSharingCode })
+      .matchHeader('Authorization', 'Bearer some-token')
+      .reply(400);
+
+    history.push(`/scan-callback?sharingCode=${mockSharingCode}`);
+
+    await waitFor(() => expect(history.location.pathname).toBe('/scan'));
+  });
+});

--- a/src/scanning/ScanCallbackPage.tsx
+++ b/src/scanning/ScanCallbackPage.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect } from 'react';
+import { Spinner } from 'theme-ui';
+import { useHistory, useLocation } from 'react-router-dom';
+import http from 'axios';
+
+import { createAccessPass } from '../api';
+import { useAuthentication } from '../authentication';
+import { UUID_VALIDATION_REGEX } from './UUID_VALIDATION_REGEX';
+
+export const ScanCallbackPage = () => {
+  const queryParams = useQuery();
+  const { userId, token } = useAuthentication();
+  const history = useHistory();
+
+  const sharingCode = queryParams.get('sharingCode');
+
+  useEffect(() => {
+    const cancelToken = http.CancelToken.source();
+
+    async function run() {
+      if (sharingCode && userId && token) {
+        if (sharingCode.match(UUID_VALIDATION_REGEX)) {
+          try {
+            const accessPass = await createAccessPass(userId, sharingCode, {
+              token,
+              cancelToken: cancelToken.token,
+            });
+
+            history.push(`/users/${accessPass.userId}`);
+          } catch (error) {
+            if (!http.isCancel(error)) {
+              history.replace('/scan');
+            }
+          }
+        } else {
+          history.replace('/scan');
+        }
+      }
+    }
+
+    run();
+
+    return () => cancelToken.cancel();
+  }, [history, sharingCode, token, userId]);
+
+  return <Spinner variant="spinner.main" />;
+};
+
+function useQuery() {
+  return new URLSearchParams(useLocation().search);
+}

--- a/src/scanning/ScanPage.test.tsx
+++ b/src/scanning/ScanPage.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Router } from 'react-router-dom';
 import { act } from 'react-dom/test-utils';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import QRReader from 'react-qr-reader';
 import { createMemoryHistory, History } from 'history';
 
@@ -21,7 +21,7 @@ const mockToken = 'mock-token';
 const mockUser = 'mock-user';
 const mockSharingCode = 'dca03948-51d0-4501-aabb-39bd08a0e60e';
 
-describe('Identity page', () => {
+describe('Scan page', () => {
   let history: History;
   let mockScan: (data: string | null) => any;
   let mockScanError: (error: Error) => any;
@@ -65,20 +65,20 @@ describe('Identity page', () => {
       .matchHeader('Authorization', `Bearer ${mockToken}`)
       .reply(200, { userId: 'mock-patient-id', expiryTime: new Date().toISOString() });
     expect(history.location.pathname).not.toBe('/users/mock-user');
-    await mockScan(mockSharingCode);
+    await mockScan(`https://example.com?sharingCode=${mockSharingCode}`);
     expect(history.location.pathname).toBe('/users/mock-patient-id');
   });
 
   it('does not try to create access passes for invalid sharing codes', async () => {
     const scope = nock(/./).post('/api/v1/users/mock-user/access-passes').reply(500);
-    await mockScan('wrong-data');
+    await mockScan('https://example.com?sharingCode=wrong-data');
     await mockScan(null);
     expect(scope.isDone()).toBe(false);
   });
 
   it('shows errors for incorrect codes', async () => {
     expect(screen.queryByText(/incorrect/i)).not.toBeTruthy();
-    await mockScan('wrong-data');
+    await mockScan('https://example.com?sharingCode=wrong-data');
     expect(screen.queryByText(/incorrect/i)).toBeTruthy();
   });
 
@@ -88,12 +88,12 @@ describe('Identity page', () => {
       .matchHeader('Authorization', `Bearer ${mockToken}`)
       .reply(400);
     expect(screen.queryByText(/incorrect/i)).not.toBeTruthy();
-    await mockScan(mockSharingCode);
+    await mockScan(`https://example.com?sharingCode=${mockSharingCode}`);
     expect(screen.queryByText(/incorrect/i)).toBeTruthy();
   });
 
   it('clears errors after a time', async () => {
-    await mockScan('wrong-data');
+    await mockScan('https://example.com?sharingCode=wrong-data');
     expect(screen.queryByText(/incorrect/i)).toBeTruthy();
     act(() => {
       jest.advanceTimersByTime(10000);

--- a/src/scanning/ScanPage.tsx
+++ b/src/scanning/ScanPage.tsx
@@ -6,7 +6,7 @@ import { createAccessPass } from '../api';
 import { useAuthentication } from '../authentication';
 import { useTranslations, Message } from 'retranslate';
 
-const uuidValidationRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+import { UUID_VALIDATION_REGEX } from './UUID_VALIDATION_REGEX';
 
 const errorClearTimeout = 5000;
 
@@ -19,13 +19,13 @@ export const ScanPage = () => {
   const [loading, setLoading] = useState(false);
   const [legacyMode, setLegacyMode] = useState(false);
 
-  async function handleScan(data: string | null) {
-    if (data && userId && token && !loading) {
-      // TODO: embed a piece of info before uuid (cov-user?) to make sure it's our uuid
-      if (data.match(uuidValidationRegex)) {
+  async function handleScan(url: string | null) {
+    if (url && userId && token && !loading) {
+      const code = parseSharingCodeFromUrl(url);
+      if (code && code.match(UUID_VALIDATION_REGEX)) {
         setLoading(true);
         try {
-          const accessPass = await createAccessPass(userId, data, { token });
+          const accessPass = await createAccessPass(userId, code, { token });
           history.push(`/users/${accessPass.userId}`);
         } catch (e) {
           setError(translate('scanPage.error.incorrectCode'));
@@ -92,3 +92,11 @@ export const ScanPage = () => {
     </>
   );
 };
+
+function parseSharingCodeFromUrl(data: string): string | null {
+  try {
+    return new URL(data).searchParams.get('sharingCode');
+  } catch (error) {
+    return null;
+  }
+}

--- a/src/scanning/UUID_VALIDATION_REGEX.ts
+++ b/src/scanning/UUID_VALIDATION_REGEX.ts
@@ -1,0 +1,1 @@
+export const UUID_VALIDATION_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;

--- a/src/scanning/index.ts
+++ b/src/scanning/index.ts
@@ -1,1 +1,2 @@
 export * from './ScanPage';
+export * from './ScanCallbackPage';


### PR DESCRIPTION
## Context

We got feedback that the QR code is not scannable. Upon investigation, it turned out they did not use our app, but a general QR code reader instead. To prevent this, we could make the QR code link to our app.

## Changes

The QR code value is changed to a link with the sharing code rather than just the sharing code.

The link is for a new `/scan-callback` page. When the scanner is authenticated, they'll automatically get redirected to the scannee's page as with the current scan page. When not, they'll log in, see a scan button on the home screen, and scan again.